### PR TITLE
LOG table has been removed from ICAT 4.7 schema.

### DIFF
--- a/src/main/scripts/upgrade_mysql_4_7.sql
+++ b/src/main/scripts/upgrade_mysql_4_7.sql
@@ -1,2 +1,3 @@
 alter table DATACOLLECTION add DOI VARCHAR(255) AFTER CREATE_TIME;
+drop table LOG;
 drop table RULE_;

--- a/src/main/scripts/upgrade_oracle_4_7.sql
+++ b/src/main/scripts/upgrade_oracle_4_7.sql
@@ -1,3 +1,4 @@
 alter table DATACOLLECTION add DOI VARCHAR2(255);
+drop table LOG;
 drop table RULE_;
 exit


### PR DESCRIPTION
LOG table has been removed from ICAT 4.7 schema, so I guess, it should also be removed by the upgrade script.