### PR TITLE
Update authn.anon.jndi to current release version in icat.properties.example

### DIFF
--- a/src/main/config/icat.properties.example
+++ b/src/main/config/icat.properties.example
@@ -31,7 +31,7 @@ authn.ldap.friendly = Federal Id
 
 authn.simple.jndi = java:global/authn.simple-1.1.0/SIMPLE_Authenticator
 
-authn.anon.jndi     = java:global/authn.anon-1.1.0/ANON_Authenticator
+authn.anon.jndi     = java:global/authn.anon-1.1.1/ANON_Authenticator
 authn.anon.friendly = Anonymous
 
 # Uncomment to permit configuration of logback


### PR DESCRIPTION
I suggest the jndi entries in icat.properties.example should correspond to the current release versions of the authenticators.  The entry for auth.anon was out of date.
