### PR TITLE
Update httpclient version due to security alert

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -124,7 +124,7 @@
 		<dependency>
 			<groupId>org.apache.httpcomponents</groupId>
 			<artifactId>httpclient</artifactId>
-			<version>4.3.4</version>
+			<version>4.3.6</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
Updates Apache HttpClient from 4.3.4 to 4.3.6. Passes unit tests and integration tests.