### PR TITLE
Configure indexable entities

### DIFF
--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -48,6 +48,8 @@ lucene.populateBlockSize = 10000
 lucene.directory = ${HOME}/data/icat/lucene
 lucene.backlogHandlerIntervalSeconds = 60
 lucene.enqueuedRequestIntervalSeconds = 5
+# The entities to index with Lucene. For example, remove 'Datafile' and 'DatafileParameter' if the number of datafiles exceeds lucene's limit of 2^32 entries in an index
+!lucene.entitiesToIndex = Datafile Dataset Investigation InvestigationUser DatafileParameter DatasetParameter InvestigationParameter Sample
 
 # List members of cluster
 !cluster = http://vm200.nubes.stfc.ac.uk:8080 https://smfisher:8181				

--- a/src/main/java/org/icatproject/core/manager/LuceneManager.java
+++ b/src/main/java/org/icatproject/core/manager/LuceneManager.java
@@ -13,8 +13,10 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.Set;
 import java.util.List;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.SortedSet;
 import java.util.Timer;
 import java.util.TimerTask;
@@ -336,14 +338,16 @@ public class LuceneManager {
 	private Long queueFileLock = 0L;
 
 	private Timer timer;
+	
+	private Set<String> entitiesToIndex;
 
 	private File backlogHandlerFile;
 
 	private File queueFile;
 
 	public void addDocument(EntityBaseBean bean) throws IcatException {
-		if (eiHandler.hasLuceneDoc(bean.getClass())) {
-			String entityName = bean.getClass().getSimpleName();
+		String entityName = bean.getClass().getSimpleName();
+		if (eiHandler.hasLuceneDoc(bean.getClass()) && entitiesToIndex.contains(entityName)) {
 			ByteArrayOutputStream baos = new ByteArrayOutputStream();
 			try (JsonGenerator gen = Json.createGenerator(baos)) {
 				gen.writeStartArray();
@@ -488,6 +492,7 @@ public class LuceneManager {
 						propertyHandler.getLuceneBacklogHandlerIntervalMillis());
 				timer.schedule(new EnqueuedLuceneRequestHandler(), 0L,
 						propertyHandler.getLuceneEnqueuedRequestIntervalMillis());
+				entitiesToIndex = propertyHandler.getEntitiesToIndex();
 				logger.info("Initialised LuceneManager at {}", url);
 			} catch (Exception e) {
 				logger.error(fatal, "Problem setting up LuceneManager", e);
@@ -534,8 +539,8 @@ public class LuceneManager {
 	}
 
 	public void updateDocument(EntityBaseBean bean) throws IcatException {
-		if (eiHandler.hasLuceneDoc(bean.getClass())) {
-			String entityName = bean.getClass().getSimpleName();
+		String entityName = bean.getClass().getSimpleName();
+		if (eiHandler.hasLuceneDoc(bean.getClass()) && entitiesToIndex.contains(entityName)) {
 			ByteArrayOutputStream baos = new ByteArrayOutputStream();
 			try (JsonGenerator gen = Json.createGenerator(baos)) {
 				gen.writeStartArray();

--- a/src/main/java/org/icatproject/core/manager/PropertyHandler.java
+++ b/src/main/java/org/icatproject/core/manager/PropertyHandler.java
@@ -273,6 +273,16 @@ public class PropertyHandler {
 		return rootUserNames;
 	}
 
+	
+	/**
+	 * Configure which entities will be indexed by lucene on ingest
+	 */
+	private Set<String> entitiesToIndex = new HashSet<String>();
+	
+	public Set<String> getEntitiesToIndex() {
+		return entitiesToIndex;
+	}
+	
 	public int getLifetimeMinutes() {
 		return lifetimeMinutes;
 	}
@@ -368,6 +378,25 @@ public class PropertyHandler {
 			}
 			formattedProps.add("rootUserNames " + names);
 
+			/* entitiesToIndex */
+			key = "lucene.entitiesToIndex";
+			if (props.has(key)) {
+				String indexableEntities = props.getString(key);
+				for (String indexableEntity : indexableEntities.split("\\s+")) {
+					entitiesToIndex.add(indexableEntity);
+				}
+				logger.info("lucene.entitiesToIndex: {}", entitiesToIndex.toString());
+			} else {
+				/* If the property is not specified, we default to all the entities which
+				 * currently override the EntityBaseBean.getDoc() method. This should
+				 * result in no change to behaviour if the property is not specified.
+				 */
+				entitiesToIndex.addAll(Arrays.asList("Datafile", "Dataset", "Investigation", "InvestigationUser", 
+						"DatafileParameter", "DatasetParameter", "InvestigationParameter", "Sample"));
+				logger.info("lucene.entitiesToIndex not set. Defaulting to: {}", entitiesToIndex.toString());
+			}
+			formattedProps.add("lucene.entitiesToIndex " + entitiesToIndex.toString());
+			
 			/* notification.list */
 			key = "notification.list";
 			if (props.has(key)) {

--- a/src/main/resources/run.properties
+++ b/src/main/resources/run.properties
@@ -1,21 +1,13 @@
 # This default run.properties file is only used in development
 lifetimeMinutes = 120
-rootUserNames = db/root
+rootUserNames = simple/root
 maxEntities = 10000
 maxIdsInQuery = 500
 importCacheSize = 50
 exportCacheSize = 50
-authn.list = db ldap simple anon
-authn.db.url       = https://smfisher:8181
+authn.list = simple
 
-authn.ldap.url     = https://smfisher:8181
-authn.ldap.admin    = true
-authn.ldap.friendly = Federal Id
-
-authn.simple.url     = https://smfisher:8181
-
-authn.anon.url     = https://smfisher:8181
-authn.anon.friendly = Anonymous
+authn.simple.url     = https://localhost.localdomain:18181
 
 notification.list = Dataset Datafile
 notification.Dataset = CU
@@ -23,11 +15,12 @@ notification.Datafile = CU
 
 log.list = SESSION WRITE READ INFO
 
-lucene.url = https://smfisher:8181
+lucene.url = https://localhost.localdomain:18181
 lucene.populateBlockSize = 10000
 lucene.directory = ${HOME}/data/icat/lucene
 lucene.backlogHandlerIntervalSeconds = 60
 lucene.enqueuedRequestIntervalSeconds = 3
+lucene.entitiesToIndex = Datafile Dataset Investigation InvestigationUser DatafileParameter DatasetParameter InvestigationParameter Sample
 
 !cluster = https://smfisher:8181
 

--- a/src/main/resources/run.properties
+++ b/src/main/resources/run.properties
@@ -1,13 +1,14 @@
 # This default run.properties file is only used in development
 lifetimeMinutes = 120
-rootUserNames = simple/root
+rootUserNames = db/root simple/root
 maxEntities = 10000
 maxIdsInQuery = 500
 importCacheSize = 50
 exportCacheSize = 50
-authn.list = simple
+authn.list = db simple
 
-authn.simple.url     = https://localhost.localdomain:18181
+authn.db.url     = https://localhost.localdomain:8181
+authn.simple.url     = https://localhost.localdomain:8181
 
 notification.list = Dataset Datafile
 notification.Dataset = CU
@@ -15,12 +16,14 @@ notification.Datafile = CU
 
 log.list = SESSION WRITE READ INFO
 
-lucene.url = https://localhost.localdomain:18181
+lucene.url = https://localhost.localdomain:8181
 lucene.populateBlockSize = 10000
-lucene.directory = ${HOME}/data/icat/lucene
+lucene.directory = ${HOME}/data/lucene
 lucene.backlogHandlerIntervalSeconds = 60
 lucene.enqueuedRequestIntervalSeconds = 3
-lucene.entitiesToIndex = Datafile Dataset Investigation InvestigationUser DatafileParameter DatasetParameter InvestigationParameter Sample
+# Configure this option to prevent certain entities being indexed
+# For example, remove Datafile and DatafileParameter
+!lucene.entitiesToIndex = Datafile Dataset Investigation InvestigationUser DatafileParameter DatasetParameter InvestigationParameter Sample
 
 !cluster = https://smfisher:8181
 


### PR DESCRIPTION
Adds a new configuration option in the run.properties (lucene.entitiesToIndex) to list the entities which Lucene should index (for example, on ingest). 

If the property is not specified, we default to all the entities which currently override the EntityBaseBean.getDoc() method. This should result in no change to behaviour if the property is not specified.

This allows a site to remove, for example, Datafiles from the Lucene index if they have more than 2^32 files in their archive.