### PR TITLE
try-with-resource JMS Session to send messages. Fixes #202 - again!

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
 		<dependency>
 			<groupId>commons-fileupload</groupId>
 			<artifactId>commons-fileupload</artifactId>
-			<version>1.3</version>
+			<version>1.3.3</version>
 		</dependency>
 
 		<dependency>

--- a/src/main/java/org/icatproject/core/manager/Transmitter.java
+++ b/src/main/java/org/icatproject/core/manager/Transmitter.java
@@ -62,8 +62,8 @@ public class Transmitter {
 	}
 
 	public void processMessage(String operation, String ip, String body, long startMillis) {
-		try {
-			Session jmsSession = topicConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+		try ( Session jmsSession = topicConnection.createSession(false, Session.AUTO_ACKNOWLEDGE) )
+		{
 			TextMessage jmsg = jmsSession.createTextMessage(body);
 			jmsg.setStringProperty("operation", operation);
 			jmsg.setStringProperty("ip", ip);
@@ -72,7 +72,6 @@ public class Transmitter {
 			MessageProducer jmsProducer = jmsSession.createProducer(topic);
 			jmsProducer.send(jmsg);
 			logger.debug("Sent jms message " + operation + " " + ip);
-			jmsSession.close();
 		} catch (JMSException e) {
 			logger.error("Failed to send jms message " + operation + " " + ip);
 		}

--- a/src/site/xhtml/release-notes.xhtml
+++ b/src/site/xhtml/release-notes.xhtml
@@ -6,6 +6,13 @@
 
 	<h1>ICAT Server Release Notes</h1>
 
+	<h2>4.9.3</h2>
+	<p>Bug fixes</p>
+	<ul>
+		<li>Make the message transmitters more fault-tolerant.</li>
+		<li>Upgrade commons-fileupload from 1.3 to 1.3.3 because of security vulnerabilities (<a href="https://nvd.nist.gov/vuln/detail/CVE-2016-3092">CVE-2016-3092</a>, <a href="https://nvd.nist.gov/vuln/detail/CVE-2016-1000031">CVE-2016-1000031</a>, <a href="https://nvd.nist.gov/vuln/detail/CVE-2014-0050">CVE-2014-0050</a>).</li>
+	</ul>
+
 	<h2>4.9.2</h2>
 	<p>Bug fixes</p>
 	<ul>


### PR DESCRIPTION
In Transmitter.java, moves the creation of the Session to a try-with-resource statement – so the Session is recreated with each call to processMessage and will be closed properly if any exception is thrown.