### PR TITLE
Use @Before and @After to setup and clear session in integration tests

### DIFF
--- a/src/test/java/org/icatproject/integration/TestRS.java
+++ b/src/test/java/org/icatproject/integration/TestRS.java
@@ -49,6 +49,8 @@ import org.icatproject.icat.client.Session.DuplicateAction;
 import org.junit.BeforeClass;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.Before;
+import org.junit.After;
 
 /**
  * These tests are for those aspects that cannot be tested by the core tests. In
@@ -70,10 +72,20 @@ public class TestRS {
 		}
 	}
 
+	@Before
+	public void initializeSession() throws Exception {
+		wSession.setAuthz();
+	}
+
+	@After
+	public void clearSession() throws Exception {
+		wSession.clear();
+		wSession.clearAuthz();
+	}
+
 	@Ignore("Test fails because of bug in eclipselink")
 	@Test
 	public void testDistinctBehaviour() throws Exception {
-		wSession.clear();
 		ICAT icat = new ICAT(System.getProperty("serverUrl"));
 		Map<String, String> credentials = new HashMap<>();
 		credentials.put("username", "root");
@@ -329,7 +341,6 @@ public class TestRS {
 	}
 
 	private Session setupLuceneTest() throws Exception {
-		wSession.setAuthz();
 		ICAT icat = new ICAT(System.getProperty("serverUrl"));
 		Map<String, String> credentials = new HashMap<>();
 		credentials.put("username", "notroot");
@@ -351,7 +362,6 @@ public class TestRS {
 		System.out.println(props);
 
 		// Get known configuration
-		wSession.clear();
 		Path path = Paths.get(ClassLoader.class.getResource("/icat.port").toURI());
 		session.importMetaData(path, DuplicateAction.CHECK, Attributes.USER);
 
@@ -394,10 +404,8 @@ public class TestRS {
 		Session session = icat.login("db", credentials);
 
 		// Get known configuration
-		wSession.clear();
 		Path path = Paths.get(ClassLoader.class.getResource("/icat.port").toURI());
 		session.importMetaData(path, DuplicateAction.CHECK, Attributes.USER);
-		wSession.setAuthz();
 
 		long fid = search(session, "Facility.id", 1).getJsonNumber(0).longValueExact();
 
@@ -428,10 +436,8 @@ public class TestRS {
 		Session session = icat.login("db", credentials);
 
 		// Get known configuration
-		wSession.clear();
 		Path path = Paths.get(ClassLoader.class.getResource("/icat.port").toURI());
 		session.importMetaData(path, DuplicateAction.CHECK, Attributes.USER);
-		wSession.setAuthz();
 
 		JsonArray array;
 
@@ -488,10 +494,8 @@ public class TestRS {
 		Session session = icat.login("db", credentials);
 
 		// Get known configuration
-		wSession.clear();
 		Path path = Paths.get(ClassLoader.class.getResource("/icat.port").toURI());
 		session.importMetaData(path, DuplicateAction.CHECK, Attributes.USER);
-		wSession.setAuthz();
 
 		JsonArray array;
 
@@ -596,7 +600,6 @@ public class TestRS {
 
 	@Test
 	public void authzForUpdateAttribute() throws Exception {
-		wSession.setAuthz();
 		Session session = createAndPopulate();
 
 		// Just start with Facility, two InvestigationTypes and Investigation
@@ -738,7 +741,6 @@ public class TestRS {
 
 	@Test
 	public void authzForUpdate() throws Exception {
-		wSession.setAuthz();
 		Session session = createAndPopulate();
 
 		// Make sure that fetching a non-id Double gives no problems
@@ -1249,7 +1251,6 @@ public class TestRS {
 	}
 
 	private Session createAndPopulate() throws Exception {
-		wSession.setAuthz();
 		ICAT icat = new ICAT(System.getProperty("serverUrl"));
 		Map<String, String> credentials = new HashMap<>();
 		credentials.put("username", "notroot");
@@ -1257,10 +1258,8 @@ public class TestRS {
 		Session session = icat.login("db", credentials);
 
 		// Get known configuration
-		wSession.clear();
 		Path path = Paths.get(ClassLoader.class.getResource("/icat.port").toURI());
 		session.importMetaData(path, DuplicateAction.CHECK, Attributes.USER);
-		wSession.setAuthz();
 
 		return session;
 	}
@@ -1381,7 +1380,6 @@ public class TestRS {
 	}
 
 	private void exportMetaDataDump(Map<String, String> credentials) throws Exception {
-		wSession.clear();
 		ICAT icat = new ICAT(System.getProperty("serverUrl"));
 		Session session = icat.login("db", credentials);
 		Path path = Paths.get(ClassLoader.class.getResource("/icat.port").toURI());
@@ -1393,7 +1391,6 @@ public class TestRS {
 
 		// Get known configuration
 		rootSession.importMetaData(path, DuplicateAction.CHECK, Attributes.ALL);
-		wSession.setAuthz();
 
 		Path dump1 = Files.createTempFile("dump1", ".tmp");
 		Path dump2 = Files.createTempFile("dump2", ".tmp");
@@ -1419,7 +1416,6 @@ public class TestRS {
 	@Ignore("Test fails - appears brittle to differences in timezone")
 	@Test
 	public void exportMetaDataQuery() throws Exception {
-		wSession.clear();
 		ICAT icat = new ICAT(System.getProperty("serverUrl"));
 		Map<String, String> credentials = new HashMap<>();
 		credentials.put("username", "root");
@@ -1429,7 +1425,6 @@ public class TestRS {
 
 		// Get known configuration
 		session.importMetaData(path, DuplicateAction.CHECK, Attributes.ALL);
-		wSession.setAuthz();
 
 		Path dump = Files.createTempFile("dump1", ".tmp");
 		start = System.currentTimeMillis();
@@ -1471,7 +1466,6 @@ public class TestRS {
 	}
 
 	private void importMetaData(Attributes attributes, String userName) throws Exception {
-		wSession.clear();
 		ICAT icat = new ICAT(System.getProperty("serverUrl"));
 		Map<String, String> credentials = new HashMap<>();
 		credentials.put("username", "root");


### PR DESCRIPTION
Some tests in TestRS were not properly initialising/clearing data and the order of tests being run caused tests to fail. Rather than initialising and clearing data in individual tests, refactor the code to use @Before and @After annotations to automatically perform these tasks before and after every test ran - ensuring better test seperation.