### PR TITLE
Fix integration test setup

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -321,6 +321,7 @@
 								<argument>src/test/scripts/prepare_test.py</argument>
 								<argument>${containerHome}</argument>
 								<argument>${serverUrl}</argument>
+								<argument>${luceneUrl}</argument>
 							</arguments>
 						</configuration>
 						<goals>

--- a/pom.xml
+++ b/pom.xml
@@ -316,13 +316,11 @@
 
 						<configuration>
 							<skip>${maven.install.skip}</skip>
-							<executable>asadmin</executable>
+							<executable>python</executable>
 							<arguments>
-								<argument>--echo</argument>
-								<argument>--port=4848</argument>
-								<argument>deploy</argument>
-								<argument>--force=true</argument>
-								<argument>${project.build.directory}/${project.build.finalName}.war</argument>
+								<argument>src/test/scripts/prepare_test.py</argument>
+								<argument>${containerHome}</argument>
+								<argument>${serverUrl}</argument>
 							</arguments>
 						</configuration>
 						<goals>

--- a/src/test/install/.gitignore
+++ b/src/test/install/.gitignore
@@ -1,0 +1,6 @@
+*.war
+setup*
+testicat
+icatadmin
+run*
+logback.xml

--- a/src/test/scripts/prepare_test.py
+++ b/src/test/scripts/prepare_test.py
@@ -8,11 +8,12 @@ import shutil
 from zipfile import ZipFile
 import subprocess
 
-if len(sys.argv) != 3:
+if len(sys.argv) != 4:
     raise RuntimeError("Wrong number of arguments")
 
 containerHome = sys.argv[1]
-url = sys.argv[2]
+icat_url = sys.argv[2]
+lucene_url = sys.argv[3]
 
 subst = dict(os.environ)
 
@@ -32,13 +33,13 @@ if not os.path.exists("src/test/install/run.properties"):
             "importCacheSize = 50",
             "exportCacheSize = 50",
             "authn.list = db simple",
-            "authn.db.url = %s" % url,
-            "authn.simple.url = %s" % url,
+            "authn.db.url = %s" % icat_url,
+            "authn.simple.url = %s" % icat_url,
             "notification.list = Dataset Datafile",
             "notification.Dataset = CU",
             "notification.Datafile = CU",
             "log.list = SESSION WRITE READ INFO",
-            "lucene.url = %s" % url,
+            "lucene.url = %s" % lucene_url,
             "lucene.populateBlockSize = 10000",
             "lucene.directory = %s/data/lucene" % subst["HOME"],
             "lucene.backlogHandlerIntervalSeconds = 60",
@@ -52,6 +53,7 @@ if not os.path.exists("src/test/install/setup.properties"):
         contents = [
             "# Glassfish",
             "secure         = true",
+            "container      = Glassfish",
             "home           = %s" % containerHome,
             "port           = 4848",
             "# MySQL",
@@ -77,6 +79,10 @@ if not os.path.exists("src/test/install/logback.xml"):
         with open("src/test/install/logback.xml", "wt") as f:
             t = Template(s.read()).substitute(subst)
             f.write(t)
+
+binDir = subst["HOME"] + "/bin"
+if not os.path.exists(binDir):
+    os.mkdir(binDir)
 
 p = subprocess.Popen(["./setup", "install"], cwd="src/test/install")
 p.wait()

--- a/src/test/scripts/prepare_test.py
+++ b/src/test/scripts/prepare_test.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+from __future__ import print_function
+import sys
+import os
+from string import Template
+import glob
+import shutil
+from zipfile import ZipFile
+import subprocess
+
+if len(sys.argv) != 3:
+    raise RuntimeError("Wrong number of arguments")
+
+containerHome = sys.argv[1]
+url = sys.argv[2]
+
+subst = dict(os.environ)
+
+for f in glob.glob("src/test/install/*.war"):
+    os.remove(f)
+
+shutil.copy("src/main/config/run.properties.example",
+            "src/test/install/run.properties.example")
+
+if not os.path.exists("src/test/install/run.properties"):
+    with open("src/test/install/run.properties", "w") as f:
+        contents = [
+            "lifetimeMinutes = 120",
+            "rootUserNames = db/root simple/root",
+            "maxEntities = 10000",
+            "maxIdsInQuery = 500",
+            "importCacheSize = 50",
+            "exportCacheSize = 50",
+            "authn.list = db simple",
+            "authn.db.url = %s" % url,
+            "authn.simple.url = %s" % url,
+            "notification.list = Dataset Datafile",
+            "notification.Dataset = CU",
+            "notification.Datafile = CU",
+            "log.list = SESSION WRITE READ INFO",
+            "lucene.url = %s" % url,
+            "lucene.populateBlockSize = 10000",
+            "lucene.directory = %s/data/lucene" % subst["HOME"],
+            "lucene.backlogHandlerIntervalSeconds = 60",
+            "lucene.enqueuedRequestIntervalSeconds = 3",
+            "key = wombat"
+        ]
+        f.write("\n".join(contents))
+
+if not os.path.exists("src/test/install/setup.properties"):
+    with open("src/test/install/setup.properties", "w") as f:
+        contents = [
+            "# Glassfish",
+            "secure         = true",
+            "home           = %s" % containerHome,
+            "port           = 4848",
+            "# MySQL",
+            "db.driver      = com.mysql.jdbc.jdbc2.optional.MysqlDataSource",
+            "db.url         = jdbc:mysql://localhost:3306/icatdb",
+            "db.username    = icatdbuser",
+            "db.password    = icatdbuserpw"
+        ]
+        f.write("\n".join(contents))
+
+shutil.copy(glob.glob("target/icat.server-*.war")[0], "src/test/install/")
+shutil.copy("src/main/scripts/setup", "src/test/install/")
+shutil.copy("src/main/scripts/testicat", "src/test/install/")
+shutil.copy("src/main/scripts/icatadmin", "src/test/install/")
+
+
+with ZipFile(glob.glob("target/icat.server-*-distro.zip")[0]) as z:
+    with open("src/test/install/setup_utils.py", "wb") as f:
+        f.write(z.read("icat.server/setup_utils.py"))
+
+if not os.path.exists("src/test/install/logback.xml"):
+    with open("src/main/resources/logback.xml", "rt") as s:
+        with open("src/test/install/logback.xml", "wt") as f:
+            t = Template(s.read()).substitute(subst)
+            f.write(t)
+
+p = subprocess.Popen(["./setup", "install"], cwd="src/test/install")
+p.wait()


### PR DESCRIPTION
Closes #205 

Adds a `prepare_test.py` based on the `ids.server` script that creates suitable test `run.properties` and `setup.properties` (if those files don't already exist in `src/test/install`) and copies other files neccessary to run `./setup install`. This script is then called in the `pre-integration-test` stage. This thus performs a proper installation of `icat.server` upon `mvn install`.

This PR fixes all the remaining issues highlighted in #205 so would close that issue. It would also help fix icatproject-contrib/icat-ansible#4 when combined with icatproject-contrib/icat-ansible#5