### PR TITLE
Allow multiple field selection in SOAP interface

### DIFF
--- a/src/main/java/org/icatproject/core/entity/FieldSet.java
+++ b/src/main/java/org/icatproject/core/entity/FieldSet.java
@@ -6,7 +6,7 @@ import java.io.Serializable;
 
 @XmlRootElement
 public class FieldSet implements Serializable {
-    @XmlElement(name = "field")
+    @XmlElement(name = "fields")
     private Object[] items;
 
     public FieldSet() {

--- a/src/main/java/org/icatproject/core/entity/FieldSet.java
+++ b/src/main/java/org/icatproject/core/entity/FieldSet.java
@@ -1,0 +1,27 @@
+package org.icatproject.core.entity;
+
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlElement;
+import java.io.Serializable;
+
+@XmlRootElement
+public class FieldSet implements Serializable {
+    @XmlElement(name = "field")
+    private Object[] items;
+
+    public FieldSet() {
+        items = new Object[0];
+    }
+
+    public FieldSet(Object[] items) {
+        this.items = items;
+    }
+
+    public Object[] getItems() {
+        return items;
+    }
+
+    public void setItems() {
+        this.items = items;
+    }
+}

--- a/src/main/java/org/icatproject/core/entity/FieldSet.java
+++ b/src/main/java/org/icatproject/core/entity/FieldSet.java
@@ -7,21 +7,21 @@ import java.io.Serializable;
 @XmlRootElement
 public class FieldSet implements Serializable {
     @XmlElement(name = "fields")
-    private Object[] items;
+    private Object[] fields;
 
     public FieldSet() {
-        items = new Object[0];
+        fields = new Object[0];
     }
 
-    public FieldSet(Object[] items) {
-        this.items = items;
+    public FieldSet(Object[] fields) {
+        this.fields = fields;
     }
 
-    public Object[] getItems() {
-        return items;
+    public Object[] getFields() {
+        return fields;
     }
 
-    public void setItems() {
-        this.items = items;
+    public void setFields() {
+        this.fields = fields;
     }
 }

--- a/src/main/java/org/icatproject/exposed/ICAT.java
+++ b/src/main/java/org/icatproject/exposed/ICAT.java
@@ -214,7 +214,7 @@ public class ICAT {
 			@WebParam DataCollectionParameter dataCollectionParameter,
 			@WebParam DataCollectionDataset dataCollectionDataset,
 			@WebParam DataCollectionDatafile dataCollectionDatafile, @WebParam Grouping group,
-			@WebParam UserGroup userGroup, @WebParam PublicStep publicStep, @WebParam FieldSet fieldset) {
+			@WebParam UserGroup userGroup, @WebParam PublicStep publicStep, @WebParam FieldSet fieldSet) {
 	}
 
 	@WebMethod

--- a/src/main/java/org/icatproject/exposed/ICAT.java
+++ b/src/main/java/org/icatproject/exposed/ICAT.java
@@ -65,6 +65,7 @@ import org.icatproject.core.entity.StudyInvestigation;
 import org.icatproject.core.entity.StudyStatus;
 import org.icatproject.core.entity.User;
 import org.icatproject.core.entity.UserGroup;
+import org.icatproject.core.entity.FieldSet;
 import org.icatproject.core.manager.AccessType;
 import org.icatproject.core.manager.AuthenticatorInfo;
 import org.icatproject.core.manager.CreateResponse;
@@ -213,7 +214,7 @@ public class ICAT {
 			@WebParam DataCollectionParameter dataCollectionParameter,
 			@WebParam DataCollectionDataset dataCollectionDataset,
 			@WebParam DataCollectionDatafile dataCollectionDatafile, @WebParam Grouping group,
-			@WebParam UserGroup userGroup, @WebParam PublicStep publicStep) {
+			@WebParam UserGroup userGroup, @WebParam PublicStep publicStep, @WebParam FieldSet fieldset) {
 	}
 
 	@WebMethod
@@ -380,7 +381,21 @@ public class ICAT {
 			String userId = getUserName(sessionId);
 			String ip = ((HttpServletRequest) webServiceContext.getMessageContext().get(MessageContext.SERVLET_REQUEST))
 					.getRemoteAddr();
-			return beanManager.search(userId, query, manager, ip);
+			List<?> result = beanManager.search(userId, query, manager, ip);
+			// special handling for fieldsets so they can be marshalled 
+			if (!result.isEmpty() && result.get(0) instanceof Object[]) {
+				List<FieldSet> newResults = new ArrayList<FieldSet>();
+				for (int i = 0; i < result.size(); i++) {
+					if (result.get(i) instanceof Object[]) {
+						FieldSet fieldSet = new FieldSet((Object[]) result.get(i));
+						newResults.add(fieldSet);
+					} else {
+						logger.warn("Something in the fieldset isn't an Object[]");
+					}
+				}
+				result = newResults;
+			}
+			return result;
 		} catch (IcatException e) {
 			reportIcatException(e);
 			throw e;

--- a/src/test/java/org/icatproject/integration/TestWS.java
+++ b/src/test/java/org/icatproject/integration/TestWS.java
@@ -34,6 +34,7 @@ import org.icatproject.EntityBaseBean;
 import org.icatproject.EntityField;
 import org.icatproject.EntityInfo;
 import org.icatproject.Facility;
+import org.icatproject.FieldSet;
 import org.icatproject.Grouping;
 import org.icatproject.IcatException;
 import org.icatproject.IcatExceptionType;
@@ -1749,6 +1750,14 @@ public class TestWS {
 		assertEquals("Count", 6, results.size());
 		assertEquals("Result", "bill", results.get(0));
 		assertEquals("Result", "fred", results.get(1));
+
+		results = session.search("SELECT df.name, df.fileSize FROM Datafile df ORDER BY df.name");
+		assertEquals("Count", 6, results.size());
+
+		assertEquals("Result", "bill", ((FieldSet) results.get(0)).getFields().get(0));
+		assertEquals("Result", 17L, ((FieldSet) results.get(0)).getFields().get(1));
+		assertEquals("Result", "fred", ((FieldSet) results.get(1)).getFields().get(0));
+		assertEquals("Result", 11L, ((FieldSet) results.get(1)).getFields().get(1));
 
 		results = session.search("SELECT df.name FROM Datafile df ORDER BY df.name LIMIT 0,1");
 		assertEquals("Count", 1, results.size());


### PR DESCRIPTION
This PR fixes the issue where an error would occur if a user attempts to use the SOAP interface for a query such as `SELECT i.name, i.title FROM Investigation i`. It creates a FieldSet entity that enables to marshaller to convert the results into XML. We have to perform some type introspection in order to be able to cast the results to FieldSet objects so they can be marshalled.