### PR TITLE
Use date instead of startDate endDate for DF #264

### DIFF
--- a/src/test/java/org/icatproject/core/manager/TestLucene.java
+++ b/src/test/java/org/icatproject/core/manager/TestLucene.java
@@ -209,7 +209,7 @@ public class TestLucene {
 		luceneApi.freeSearcher(lsr.getUid());
 
 		lsr = luceneApi.datafiles(null, null, new Date(now + 60000 * 3), new Date(now + 60000 * 6), null, 100);
-		checkLsr(lsr, 3L, 4L, 5L);
+		checkLsr(lsr, 3L, 4L, 5L, 6L);
 		luceneApi.freeSearcher(lsr.getUid());
 
 		lsr = luceneApi.datafiles("b1", "dsddd", new Date(now + 60000 * 3), new Date(now + 60000 * 6), null, 100);
@@ -563,8 +563,7 @@ public class TestLucene {
 						+ letters.substring(j, j + 1);
 				gen.writeStartArray();
 				LuceneApi.encodeTextfield(gen, "text", word);
-				LuceneApi.encodeStringField(gen, "startDate", new Date(now + i * 60000));
-				LuceneApi.encodeStringField(gen, "endDate", new Date(now + (i + 1) * 60000));
+				LuceneApi.encodeStringField(gen, "date", new Date(now + i * 60000));
 				LuceneApi.encodeStoredId(gen, new Long(i));
 				LuceneApi.encodeStringField(gen, "dataset", new Long(i % NUMDS));
 				gen.writeEnd();

--- a/src/test/java/org/icatproject/integration/TestRS.java
+++ b/src/test/java/org/icatproject/integration/TestRS.java
@@ -687,7 +687,8 @@ public class TestRS {
 		array = search(session, "SELECT AVG(ds.id) FROM Dataset ds WHERE ds.id = 0", 1);
 		assertTrue(array.isNull(0));
 
-		array = search(session, "SELECT ds.complete FROM Dataset ds", 5);
+		// TODO this is wrong - there should be 4 false and 1 true
+		array = search(session, "SELECT ds.complete FROM Dataset ds", 4);
 		int trues = 0;
 		int falses = 0;
 		for (int i = 0; i < array.size(); i++) {
@@ -697,7 +698,7 @@ public class TestRS {
 				falses++;
 			}
 		}
-		assertEquals(1, trues);
+		assertEquals(0, trues);
 		assertEquals(4, falses);
 
 		array = search(session, "Facility INCLUDE InvestigationType", 1);

--- a/src/test/java/org/icatproject/integration/TestRS.java
+++ b/src/test/java/org/icatproject/integration/TestRS.java
@@ -687,8 +687,7 @@ public class TestRS {
 		array = search(session, "SELECT AVG(ds.id) FROM Dataset ds WHERE ds.id = 0", 1);
 		assertTrue(array.isNull(0));
 
-		// TODO this is wrong - there should be 4 false and 1 true
-		array = search(session, "SELECT ds.complete FROM Dataset ds", 4);
+		array = search(session, "SELECT ds.complete FROM Dataset ds", 5);
 		int trues = 0;
 		int falses = 0;
 		for (int i = 0; i < array.size(); i++) {
@@ -698,7 +697,7 @@ public class TestRS {
 				falses++;
 			}
 		}
-		assertEquals(0, trues);
+		assertEquals(1, trues);
 		assertEquals(4, falses);
 
 		array = search(session, "Facility INCLUDE InvestigationType", 1);


### PR DESCRIPTION
Have changed `TestLucene` to encode the `Datafile` with "date" rather than "startDate" or "endDate". As a result, when getting the results, we now get files 3 through 6. Previously, the query gets files that had both "startDate" and "endDate" in the range `now+3` to `now+6`, so ID6 was not returned as it's end date was `now+7`. As we now only have one date field which is only precise to a minute, we get ID6 as well.

~~There was another test which was failing for me in `TestRS`, which had a TODO saying how the test should pass. Making the change it described worked, however I don't know if this was due to some peculiarity in my local setup (e.g. a weird version of icat.lucene/client) so this may deserve a separate issue?~~

This now has it's own issue with further discussion: #273 
Have removed the changes to TestRS from this PR.

Closes #264 