### PR TITLE
Add getReadableIds and use in filterReadAccess #277

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -167,7 +167,7 @@
 					</execution>
 				</executions>
 				<configuration>
-					<licence>cHJvamVjdHxvcmcuaWNhdHByb2plY3QuaWNhdC5zZXJ2ZXJ8MjAxOC0wOS0xNXx0cnVlfC0xI01DMENGRzRQaDRMdlpvZlRwK0xsMmdENHFrZGR1VGtGQWhVQWk0eGh5cld4b25PTEJjWUhHS0pBbTcxa3VwST0=</licence>
+					<licence>cHJvamVjdHxvcmcuaWNhdHByb2plY3QuaWNhdC5zZXJ2ZXJ8MjAyMi0wNC0wMXxmYWxzZXwtMSNNQ3dDRkQyQzhzZWZ1aEY3UzVlV2JhdUtzU0gvaXhBZ0FoUTdjRUpDOGRHZjdWZ1RPOXo1cCsxaXZBWkxSQT09</licence>
 					<output>
 						<html>
 							<location>site/miredot</location>

--- a/src/main/config/run.properties.example
+++ b/src/main/config/run.properties.example
@@ -45,6 +45,10 @@ log.list = SESSION WRITE READ INFO
 # Lucene
 lucene.url = https://localhost:8181
 lucene.populateBlockSize = 10000
+# Recommend setting lucene.searchBlockSize equal to maxIdsInQuery, so that all Lucene results can be authorised at once
+# If lucene.searchBlockSize > maxIdsInQuery, then multiple auth checks may be needed for a single search to Lucene
+# The optimal value depends on how likely a user's auth request fails: larger values are more efficient when rejection is more likely
+lucene.searchBlockSize = 1000
 lucene.directory = ${HOME}/data/icat/lucene
 lucene.backlogHandlerIntervalSeconds = 60
 lucene.enqueuedRequestIntervalSeconds = 5

--- a/src/main/java/org/icatproject/core/entity/EntityBaseBean.java
+++ b/src/main/java/org/icatproject/core/entity/EntityBaseBean.java
@@ -31,6 +31,7 @@ import org.icatproject.core.manager.EntityBeanManager.PersistMode;
 import org.icatproject.core.manager.EntityInfoHandler;
 import org.icatproject.core.manager.EntityInfoHandler.Relationship;
 import org.icatproject.core.manager.GateKeeper;
+import org.icatproject.core.manager.HasEntityId;
 import org.icatproject.core.manager.LuceneManager;
 import org.icatproject.core.parser.IncludeClause.Step;
 import org.slf4j.Logger;
@@ -38,7 +39,7 @@ import org.slf4j.LoggerFactory;
 
 @SuppressWarnings("serial")
 @MappedSuperclass
-public abstract class EntityBaseBean implements Serializable {
+public abstract class EntityBaseBean implements HasEntityId, Serializable {
 
 	private static final EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
 

--- a/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
+++ b/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
@@ -782,6 +782,27 @@ public class EntityBeanManager {
 		}
 	}
 
+	/**
+	 * Performs authorisation for READ access on the newResults. Instead of
+	 * returning the entries which can be READ, they are added to the end of
+	 * acceptedResults, ensuring it doesn't exceed maxCount or maxEntities.
+	 * 
+	 * @param acceptedResults List containing already authorised entities. Entries
+	 *                        in newResults that pass authorisation will be added to
+	 *                        acceptedResults.
+	 * @param newResults      List containing new results to check READ access to.
+	 *                        Entries in newResults that pass authorisation will be
+	 *                        added to acceptedResults.
+	 * @param maxCount        The maximum size of acceptedResults. Once reached, no
+	 *                        more entries from newResults will be added.
+	 * @param userId          The user attempting to read the newResults.
+	 * @param manager         The EntityManager to use.
+	 * @param klass           The Class of the EntityBaseBean that is being
+	 *                        filtered.
+	 * @throws IcatException If more entities than the configuration option
+	 *                       maxEntities would be added to acceptedResults, then an
+	 *                       IcatException is thrown instead.
+	 */
 	private void filterReadAccess(List<ScoredEntityBaseBean> acceptedResults, List<ScoredEntityBaseBean> newResults,
 			int maxCount, String userId, EntityManager manager, Class<? extends EntityBaseBean> klass)
 			throws IcatException {

--- a/src/main/java/org/icatproject/core/manager/GateKeeper.java
+++ b/src/main/java/org/icatproject/core/manager/GateKeeper.java
@@ -165,9 +165,14 @@ public class GateKeeper {
 	}
 
 	/**
-	 * @param userId     The user making the READ request
-	 * @param simpleName The name of the requested entity type
-	 * @param manager
+	 * Gets READ restrictions that apply to entities of type simpleName, that are
+	 * relevant for the given userId. If userId belongs to a root user, or one of
+	 * the restrictions is itself null, then null is returned. This corresponds to a
+	 * case where the user can READ any entity of type simpleName.
+	 * 
+	 * @param userId     The user making the READ request.
+	 * @param simpleName The name of the requested entity type.
+	 * @param manager    The EntityManager to use.
 	 * @return Returns a list of restrictions that apply to the requested entity
 	 *         type. If there are no restrictions, then returns null.
 	 */
@@ -197,10 +202,12 @@ public class GateKeeper {
 
 	/**
 	 * Returns a sub list of the passed entities that the user has READ access to.
+	 * Note that this method accepts and returns instances of EntityBaseBean, unlike
+	 * getReadableIds.
 	 * 
-	 * @param userId  The user making the READ request
-	 * @param beans   The entities the user wants to READ
-	 * @param manager
+	 * @param userId  The user making the READ request.
+	 * @param beans   The entities the user wants to READ.
+	 * @param manager The EntityManager to use.
 	 * @return A list of entities the user has read access to
 	 */
 	public List<EntityBaseBean> getReadable(String userId, List<EntityBaseBean> beans, EntityManager manager) {
@@ -229,10 +236,15 @@ public class GateKeeper {
 	}
 
 	/**
-	 * @param userId     The user making the READ request
-	 * @param entities   The entities to check
-	 * @param simpleName The name of the requested entity type
-	 * @param manager
+	 * Returns a set of ids that indicate entities of type simpleName that the user
+	 * has READ access to. If all of the entities can be READ (restrictions are
+	 * null) then null is returned. Note that while this accepts anything that
+	 * HasEntityId, the ids are returned as a Set<Long> unlike getReadable.
+	 * 
+	 * @param userId     The user making the READ request.
+	 * @param entities   The entities to check.
+	 * @param simpleName The name of the requested entity type.
+	 * @param manager    The EntityManager to use.
 	 * @return Set of the ids that the user has read access to. If there are no
 	 *         restrictions, then returns null.
 	 */
@@ -252,11 +264,13 @@ public class GateKeeper {
 	}
 
 	/**
-	 * @param userId       The user making the READ request
-	 * @param entities     The entities to check
-	 * @param restrictions The restrictions applying to the entities
-	 * @param manager
-	 * @return Set of the ids that the user has read access to
+	 * Returns a set of ids that indicate entities that the user has READ access to.
+	 * 
+	 * @param userId       The user making the READ request.
+	 * @param entities     The entities to check.
+	 * @param restrictions The restrictions applying to the entities.
+	 * @param manager      The EntityManager to use.
+	 * @return Set of the ids that the user has read access to.
 	 */
 	private Set<Long> getReadableIds(String userId, List<? extends HasEntityId> entities, List<String> restrictions,
 			EntityManager manager) {

--- a/src/main/java/org/icatproject/core/manager/HasEntityId.java
+++ b/src/main/java/org/icatproject/core/manager/HasEntityId.java
@@ -1,0 +1,8 @@
+package org.icatproject.core.manager;
+
+/**
+ * Interface for objects representing entities that hold the entity id.
+ */
+public interface HasEntityId {
+	public Long getId();
+}

--- a/src/main/java/org/icatproject/core/manager/PropertyHandler.java
+++ b/src/main/java/org/icatproject/core/manager/PropertyHandler.java
@@ -302,6 +302,7 @@ public class PropertyHandler {
 	private String digestKey;
 	private URL luceneUrl;
 	private int lucenePopulateBlockSize;
+	private int luceneSearchBlockSize;
 	private Path luceneDirectory;
 	private long luceneBacklogHandlerIntervalMillis;
 	private Map<String, String> cluster = new HashMap<>();
@@ -460,8 +461,11 @@ public class PropertyHandler {
 				luceneUrl = props.getURL("lucene.url");
 				formattedProps.add("lucene.url" + " " + luceneUrl);
 
-				lucenePopulateBlockSize = props.getPositiveInt("lucene.populateBlockSize");
+				lucenePopulateBlockSize = props.getPositiveInt("lucene.searchBlockSize");
 				formattedProps.add("lucene.populateBlockSize" + " " + lucenePopulateBlockSize);
+
+				luceneSearchBlockSize = props.getPositiveInt("lucene.searchBlockSize");
+				formattedProps.add("lucene.searchBlockSize" + " " + luceneSearchBlockSize);
 
 				luceneDirectory = props.getPath("lucene.directory");
 				if (!luceneDirectory.toFile().isDirectory()) {
@@ -610,6 +614,10 @@ public class PropertyHandler {
 
 	public int getLucenePopulateBlockSize() {
 		return lucenePopulateBlockSize;
+	}
+
+	public int getLuceneSearchBlockSize() {
+		return luceneSearchBlockSize;
 	}
 
 	public long getLuceneBacklogHandlerIntervalMillis() {

--- a/src/main/java/org/icatproject/core/manager/ScoredEntityBaseBean.java
+++ b/src/main/java/org/icatproject/core/manager/ScoredEntityBaseBean.java
@@ -1,17 +1,17 @@
 package org.icatproject.core.manager;
 
-public class ScoredEntityBaseBean {
+public class ScoredEntityBaseBean implements HasEntityId {
 
-	private long entityBaseBeanId;
+	private Long id;
 	private float score;
 
-	public ScoredEntityBaseBean(long id, float score) {
-		this.entityBaseBeanId = id;
+	public ScoredEntityBaseBean(Long id, float score) {
+		this.id = id;
 		this.score = score;
 	}
 
-	public long getEntityBaseBeanId() {
-		return entityBaseBeanId;
+	public Long getId() {
+		return id;
 	}
 
 	public float getScore() {

--- a/src/main/java/org/icatproject/exposed/ICATRest.java
+++ b/src/main/java/org/icatproject/exposed/ICATRest.java
@@ -1108,7 +1108,7 @@ public class ICATRest {
 			gen.writeStartArray();
 			for (ScoredEntityBaseBean sb : objects) {
 				gen.writeStartObject();
-				gen.write("id", sb.getEntityBaseBeanId());
+				gen.write("id", sb.getId());
 				gen.write("score", sb.getScore());
 				gen.writeEnd();
 			}

--- a/src/main/resources/run.properties
+++ b/src/main/resources/run.properties
@@ -18,6 +18,10 @@ log.list = SESSION WRITE READ INFO
 
 lucene.url = https://localhost.localdomain:8181
 lucene.populateBlockSize = 10000
+# Recommend setting lucene.searchBlockSize equal to maxIdsInQuery, so that all Lucene results can be authorised at once
+# If lucene.searchBlockSize > maxIdsInQuery, then multiple auth checks may be needed for a single search to Lucene
+# The optimal value depends on how likely a user's auth request fails: larger values are more efficient when rejection is more likely
+lucene.searchBlockSize = 1000
 lucene.directory = ${HOME}/data/lucene
 lucene.backlogHandlerIntervalSeconds = 60
 lucene.enqueuedRequestIntervalSeconds = 3

--- a/src/test/java/org/icatproject/core/manager/TestLucene.java
+++ b/src/test/java/org/icatproject/core/manager/TestLucene.java
@@ -159,7 +159,7 @@ public class TestLucene {
 		Set<Long> got = new HashSet<>();
 
 		for (ScoredEntityBaseBean q : lsr.getResults()) {
-			got.add(q.getEntityBaseBeanId());
+			got.add(q.getId());
 		}
 
 		Set<Long> missing = new HashSet<>(wanted);

--- a/src/test/java/org/icatproject/integration/TestRS.java
+++ b/src/test/java/org/icatproject/integration/TestRS.java
@@ -95,8 +95,7 @@ public class TestRS {
 		Map<String, String> credentials = new HashMap<>();
 		credentials.put("username", "root");
 		credentials.put("password", "password");
-		Session session = icat.login("db", credentials);
-		return session;
+		return icat.login("db", credentials);
 	}
 
 	private Session piOneSession() throws URISyntaxException, IcatException {
@@ -104,8 +103,7 @@ public class TestRS {
 		Map<String, String> credentials = new HashMap<>();
 		credentials.put("username", "piOne");
 		credentials.put("password", "piOne");
-		Session session = icat.login("db", credentials);
-		return session;
+		return icat.login("db", credentials);
 	}
 
 	@Ignore("Test fails because of bug in eclipselink")

--- a/src/test/scripts/prepare_test.py
+++ b/src/test/scripts/prepare_test.py
@@ -41,6 +41,7 @@ if not os.path.exists("src/test/install/run.properties"):
             "log.list = SESSION WRITE READ INFO",
             "lucene.url = %s" % lucene_url,
             "lucene.populateBlockSize = 10000",
+            "lucene.searchBlockSize = 1000",
             "lucene.directory = %s/data/lucene" % subst["HOME"],
             "lucene.backlogHandlerIntervalSeconds = 60",
             "lucene.enqueuedRequestIntervalSeconds = 3",


### PR DESCRIPTION
# Changes
Added `getReadableIds` function.  The logic here is the same as in `getReadable`, however we accept and return lists of IDs rather than entities. When dealing with the free text search results, we only have IDs. Before we were finding the bean for each ID in turn in order to run authorisation on it, then proceeding to return the ID. But as we already have the `klass` of the entitity and the ID from Lucene we can simply operate on these instead.

Instead of hardcoding the number of results to get from Lucene at 1000, instead use the `maxIdsInQuery` setting. This is the limit we would send in one batch to the DB in `getReadable`/`getReadableIds` anyway, and the default value of 500 and max for Oracle of 1000 is the same order of magnitude as what we were currently using.

# Impact
I ran a number of searches against my local development components, using the [lils.yml ](https://raw.githubusercontent.com/icatproject-contrib/icat.ansible/master/files/lils.yml) as my dummy data. This contains:
| Investigations | Datasets | Datafiles |
|---------------:|----------:|---------:|
|100 | 300 | 29967|

I searched for `*` (returning all entities before authorising) as both `root` and the non-root `icatuser`, representing best and worst case scenarios (all data visible, no data visible and needing to check DB for rules) for the old and new setup with `maxIdsInQuery` set to 500 and 1000. All times are in ms, and is measured between the first `EntityBeanManager - Got X results from Lucene` and `EntityBeanManager - Returning Y results` logs made by icat.server.

## root
| Setup | Investigations | Datasets | Datafiles |
|:-------|---------------:|----------:|---------:|
| Old     | 91 | 205 | 212 | 
| New (500)| 15 | 11 | 12 |
| New (1000) | 13 | 12 | 11 |

Old method is comparable for DS and DF since we only loop until we reach 300 accepted results, then return.
New only submits one batch of entities to check, and returns in consistently ~12ms.

## non-root

| Setup | Investigations | Datasets | Datafiles |
|:-------|---------------:|----------:|---------:|
| Old     | 215 | 337 |29261 | 
| New (500)| 21 | 14 | 1502 |
| New (1000) | 15 | 14 | 690 |

Old method takes around 1 to 2 ms per entity checked as we need to check every ID individually before being sure none are authorised.
New method takes roughly the same amount of time for Investigations and DS as these both require a single batch of IDs (less than the limit in settings. Datafiles takes around half the time when the limit is doubled to 1000, as we only need to send half as many batches (averaging 24ms per batch).

Also searched for a specific single result using `id:...` in both old and new setup as root:
| Setup | Investigations | Datasets | Datafiles |
|:-------|---------------:|----------:|---------:|
| Old     | 17 | 14 | 16 | 
| New  | 11 | 15 | 14 |

Times are comparable with old and new approaches. For the new method, the time taken to authorise 1 result and hundreds (as in the `*` example) was also comparable.

It's worth noting that in these tests I didn't actually have any rules in the DB to evaluate.