### PR TITLE
Change ICAT Ansible host references to use underscores

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -38,7 +38,7 @@ jobs:
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
-          ref: underscore_changes
+          ref: master
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt
 


### PR DESCRIPTION
## Description
A PR on ICAT Ansible (https://github.com/icatproject-contrib/icat-ansible/pull/32) causes breaking changes for this repo's CI. In a sentence, dashes of host names (and its respective host file names) are changed to underscores.

When https://github.com/icatproject-contrib/icat-ansible/pull/32 is merged, the ICAT Ansible branch on the CI needs to be changed back to master. I shall leave it as `fix_warnings_#23` for the time being because the CI won't pass otherwise.

## Testing Instructions
Just check that CI passes.

- [ ] Review code
- [ ] Check GitHub Actions build
