### PR TITLE
Update logback configuration

### DIFF
--- a/src/main/config/logback.xml.example
+++ b/src/main/config/logback.xml.example
@@ -3,14 +3,11 @@
 	<appender name="FILE"
 		class="ch.qos.logback.core.rolling.RollingFileAppender">
 		<file>${HOME}/logs/icat.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
 			<fileNamePattern>${HOME}/logs/icat.log.%d{yyyy-MM-dd}.%i.zip
 			</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>30</maxHistory>
-			<timeBasedFileNamingAndTriggeringPolicy
-				class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-				<maxFileSize>100MB</maxFileSize>
-			</timeBasedFileNamingAndTriggeringPolicy>
 		</rollingPolicy>
 
 		<encoder>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -3,14 +3,11 @@
 	<appender name="FILE"
 		class="ch.qos.logback.core.rolling.RollingFileAppender">
 		<file>${HOME}/logs/icat.log</file>
-		<rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+		<rollingPolicy class="ch.qos.logback.core.rolling.SizeAndTimeBasedRollingPolicy">
 			<fileNamePattern>${HOME}/logs/icat.log.%d{yyyy-MM-dd}.%i.zip
 			</fileNamePattern>
+			<maxFileSize>100MB</maxFileSize>
 			<maxHistory>30</maxHistory>
-			<timeBasedFileNamingAndTriggeringPolicy
-				class="ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP">
-				<maxFileSize>100MB</maxFileSize>
-			</timeBasedFileNamingAndTriggeringPolicy>
 		</rollingPolicy>
 
 		<encoder>


### PR DESCRIPTION
While testing #285, I noticed a message from logback:
```
14:08:39,554 |-WARN in ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP@442299cc - SizeAndTimeBasedFNATP is deprecated. Use SizeAndTimeBasedRollingPolicy instead
14:08:39,554 |-WARN in ch.qos.logback.core.rolling.SizeAndTimeBasedFNATP@442299cc - For more information see http://logback.qos.ch/manual/appenders.html#SizeAndTimeBasedRollingPolicy
```
I'm not sure if this was already there before. But anyway, I guess while we are at it updating dependencies, we might just as well drop using deprecated features in the configuration. So I propose to update the logback configuration following the [model suggested in the documentation](http://logback.qos.ch/manual/appenders.html#SizeAndTimeBasedRollingPolicy). It even simplifies the configuration.