### PR TITLE
Use python3 instead of python

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,7 +319,7 @@
 
 						<configuration>
 							<skip>${maven.install.skip}</skip>
-							<executable>python</executable>
+							<executable>python3</executable>
 							<arguments>
 								<argument>src/test/scripts/prepare_test.py</argument>
 								<argument>${containerHome}</argument>

--- a/src/main/scripts/icatadmin
+++ b/src/main/scripts/icatadmin
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import os
@@ -128,7 +128,7 @@ def _process(relativeUrl, parameters, method, headers=None, body=None):
     
     response = conn.getresponse()
     rc = response.status
-    if (rc / 100 != 2):
+    if (rc // 100 != 2):
         try:
             responseContent = response.read()
             om = json.loads(responseContent)

--- a/src/main/scripts/rules.py
+++ b/src/main/scripts/rules.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 
 import json
@@ -44,7 +44,7 @@ def getConn(relativeUrl, method, parameters=None):
 def getResponse(conn):
     response = conn.getresponse()
     rc = response.status
-    if (rc / 100 != 2):
+    if (rc // 100 != 2):
         try:
             responseContent = response.read()
             om = json.loads(responseContent)

--- a/src/main/scripts/setup
+++ b/src/main/scripts/setup
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from setup_utils import *
 import os
 import socket

--- a/src/main/scripts/testicat
+++ b/src/main/scripts/testicat
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import logging
 import sys
@@ -7,7 +7,7 @@ import json
 import requests
 
 def check(r):
-        if r.status_code / 100 != 2:
+        if r.status_code // 100 != 2:
             json = r.json()
             if json.get("offset"):
                 print(json["code"], json["message"], json["offset"], file=sys.stderr)

--- a/src/test/scripts/prepare_test.py
+++ b/src/test/scripts/prepare_test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 from __future__ import print_function
 import sys
 import os


### PR DESCRIPTION
Modern distros often don't have a `python` command, so use `python3` explicitly.
Also corrects for a change to integer division in python3.