### PR TITLE
Fix icatadmin to run with Python 3

### DIFF
--- a/src/main/scripts/icatadmin
+++ b/src/main/scripts/icatadmin
@@ -114,7 +114,7 @@ def _process(relativeUrl, parameters, method, headers=None, body=None):
     conn.endheaders()
      
     if parameters and method == "POST":
-        conn.send(parameters)
+        conn.send(parameters.encode("ascii"))
     elif body:
         blocksize = 8192
         datablock = body.read(blocksize)

--- a/src/main/scripts/icatadmin
+++ b/src/main/scripts/icatadmin
@@ -133,7 +133,7 @@ def _process(relativeUrl, parameters, method, headers=None, body=None):
             responseContent = response.read()
             om = json.loads(responseContent)
         except Exception:
-            fatal("InternalException " + responseContent)
+            fatal("InternalException " + responseContent.decode())
         code = om["code"]
         message = om["message"]
         fatal(code + " " + message)
@@ -152,7 +152,7 @@ def getPopulating(args):
     try:
         sessionId = getService()
         parameters = {"sessionId": sessionId}
-        print(_process("lucene/db", parameters, "GET").read())
+        print(_process("lucene/db", parameters, "GET").read().decode())
     except Exception as e:
         fatal(e)
 

--- a/src/main/scripts/rules.py
+++ b/src/main/scripts/rules.py
@@ -49,7 +49,7 @@ def getResponse(conn):
             responseContent = response.read()
             om = json.loads(responseContent)
         except Exception:
-            fatal("InternalException " + responseContent)
+            fatal("InternalException " + responseContent.decode())
         code = om["code"]
         message = om["message"]
         fatal(code + " " + message)
@@ -90,7 +90,7 @@ conn = getConn("session", "POST")
 conn.putheader('Content-Type', 'application/x-www-form-urlencoded') 
 conn.putheader('Content-Length', str(len(parameters)))
 conn.endheaders()
-conn.send(parameters)
+conn.send(parameters.encode("ascii"))
 result = json.loads(getResponse(conn).read())       
 sessionId = result["sessionId"]
 
@@ -102,7 +102,7 @@ if action == "dump":
     parameters = urlencode({"json": json.dumps(jsonDump)})
     conn = getConn("port", "GET", parameters)
     conn.endheaders()
-    print(getResponse(conn).read())
+    print(getResponse(conn).read().decode())
  
 elif action == "load":
     jsonDump = {}


### PR DESCRIPTION
Debugging `icatadmin` for #305 reveals, the issue occurs in line 117:
```python
    if parameters and method == "POST":
        conn.send(parameters)
```
`parameters` is the result of a `urllib.parse.urlencode()` call, which returns a string.  `conn` is either a `http.client.HTTPConnection` or a `http.client.HTTPSConnection`, `conn.send()` seem to require a bytes-like object rather than a string (the official Python docu is not very clear in that point, but experiemts confirm this). So the obvious fix is to convert the string to bytes.

Fix #305.

Note that I only implemented a minimal fix. There are other lines of code that feed strings into `conn.send()`, as in:
```python
    elif body:
        blocksize = 8192
        datablock = body.read(blocksize)
        crc32 = 0
        while datablock:
            conn.send(hex(len(datablock))[2:] + "\r\n")
            conn.send(datablock + "\r\n")
            crc32 = zlib.crc32(datablock, crc32)
            datablock = body.read(blocksize)
        conn.send("0\r\n\r\n")
```
I didn't bother to fix those, because:

1. `icatadmin` is awkward and should probably rather be rewritten from scratch.
2. those lines cited above are actually never executed, because the keyword arguments `headers` and `body` to `_process()` are never used and thus `body` will always be `None`.