### PR TITLE
Fully-static EntityInfoHandler

### DIFF
--- a/src/main/java/org/icatproject/core/DocGenerator.java
+++ b/src/main/java/org/icatproject/core/DocGenerator.java
@@ -45,9 +45,7 @@ public class DocGenerator {
 
 		for (String cname : cnames) {
 			out.print("<hr/><h2 id=\"" + cname + "\">" + cname + "</h2>");
-			Class<?> klass = Class.forName("org.icatproject.core.entity." + cname);
-			@SuppressWarnings("unchecked")
-			Class<? extends EntityBaseBean> eklass = (Class<? extends EntityBaseBean>) klass;
+			Class<? extends EntityBaseBean> eklass = EntityInfoHandler.getClass(cname);
 			String classComment = eiHandler.getClassComment(eklass);
 			if (classComment == null) {
 				System.out.println(cname + " has no comment");

--- a/src/main/java/org/icatproject/core/DocGenerator.java
+++ b/src/main/java/org/icatproject/core/DocGenerator.java
@@ -17,8 +17,6 @@ import org.slf4j.LoggerFactory;
 
 public class DocGenerator {
 
-	private static EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
-
 	private static Logger logger = LoggerFactory.getLogger(DocGenerator.class);
 
 	public static void main(String[] args) throws Exception {
@@ -46,17 +44,17 @@ public class DocGenerator {
 		for (String cname : cnames) {
 			out.print("<hr/><h2 id=\"" + cname + "\">" + cname + "</h2>");
 			Class<? extends EntityBaseBean> eklass = EntityInfoHandler.getClass(cname);
-			String classComment = eiHandler.getClassComment(eklass);
+			String classComment = EntityInfoHandler.getClassComment(eklass);
 			if (classComment == null) {
 				System.out.println(cname + " has no comment");
 			} else {
 				out.println("<p>" + classComment + "</p>");
 			}
 
-			Set<Field> fields = new HashSet<Field>(eiHandler.getGetters(eklass).keySet());
-			Map<Field, String> fieldComments = eiHandler.getFieldComments(eklass);
-			Set<Field> notnullables = new HashSet<Field>(eiHandler.getNotNullableFields(eklass));
-			Map<Field, Integer> stringFields = eiHandler.getStringFields(eklass);
+			Set<Field> fields = new HashSet<Field>(EntityInfoHandler.getGetters(eklass).keySet());
+			Map<Field, String> fieldComments = EntityInfoHandler.getFieldComments(eklass);
+			Set<Field> notnullables = new HashSet<Field>(EntityInfoHandler.getNotNullableFields(eklass));
+			Map<Field, Integer> stringFields = EntityInfoHandler.getStringFields(eklass);
 
 			Iterator<Field> iter = fields.iterator();
 			while (iter.hasNext()) {
@@ -67,7 +65,7 @@ public class DocGenerator {
 				}
 			}
 
-			List<Field> constraint = eiHandler.getConstraintFields(eklass);
+			List<Field> constraint = EntityInfoHandler.getConstraintFields(eklass);
 			if (!constraint.isEmpty()) {
 				out.print("<p><b>Uniqueness constraint</b> ");
 				first = true;
@@ -84,7 +82,7 @@ public class DocGenerator {
 
 			out.println(
 					"<h3>Relationships</h3><table><tr><th>Card</th><th>Class</th><th>Field</th><th>Cascaded</th><th>Description</th></tr>");
-			for (Relationship r : eiHandler.getRelatedEntities(eklass)) {
+			for (Relationship r : EntityInfoHandler.getRelatedEntities(eklass)) {
 				Field f = r.getField();
 				boolean notnullable = notnullables.contains(f);
 				boolean many = r.isCollection();

--- a/src/main/java/org/icatproject/core/DocGenerator.java
+++ b/src/main/java/org/icatproject/core/DocGenerator.java
@@ -55,7 +55,7 @@ public class DocGenerator {
 				out.println("<p>" + classComment + "</p>");
 			}
 
-			Set<Field> fields = eiHandler.getGetters(eklass).keySet();
+			Set<Field> fields = new HashSet<Field>(eiHandler.getGetters(eklass).keySet());
 			Map<Field, String> fieldComments = eiHandler.getFieldComments(eklass);
 			Set<Field> notnullables = new HashSet<Field>(eiHandler.getNotNullableFields(eklass));
 			Map<Field, Integer> stringFields = eiHandler.getStringFields(eklass);

--- a/src/main/java/org/icatproject/core/entity/EntityBaseBean.java
+++ b/src/main/java/org/icatproject/core/entity/EntityBaseBean.java
@@ -40,8 +40,6 @@ import org.slf4j.LoggerFactory;
 @MappedSuperclass
 public abstract class EntityBaseBean implements Serializable {
 
-	private static final EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
-
 	private static final Logger logger = LoggerFactory.getLogger(EntityBaseBean.class);
 
 	@Column(name = "CREATE_ID", nullable = false)
@@ -84,8 +82,8 @@ public abstract class EntityBaseBean implements Serializable {
 	public void addToLucene(LuceneManager lucene) throws IcatException {
 		lucene.addDocument(this);
 		Class<? extends EntityBaseBean> klass = this.getClass();
-		Set<Relationship> rs = eiHandler.getRelatedEntities(klass);
-		Map<Field, Method> getters = eiHandler.getGetters(klass);
+		Set<Relationship> rs = EntityInfoHandler.getRelatedEntities(klass);
+		Map<Field, Method> getters = EntityInfoHandler.getGetters(klass);
 		for (Relationship r : rs) {
 			if (r.isCollection()) {
 				Method m = getters.get(r.getField());
@@ -147,9 +145,9 @@ public abstract class EntityBaseBean implements Serializable {
 
 		ids.get(beanName).add(id);
 		try {
-			Map<Field, Method> getters = eiHandler.getGetters(klass);
+			Map<Field, Method> getters = EntityInfoHandler.getGetters(klass);
 			if (one) {
-				for (Relationship r : eiHandler.getOnes(klass)) {
+				for (Relationship r : EntityInfoHandler.getOnes(klass)) {
 					Field att = r.getField();
 					EntityBaseBean value = allowedOne(r, getters.get(att), gateKeeper, userId, manager);
 					if (value != null) {
@@ -307,8 +305,8 @@ public abstract class EntityBaseBean implements Serializable {
 		}
 
 		Class<? extends EntityBaseBean> klass = this.getClass();
-		Set<Relationship> rs = eiHandler.getRelatedEntities(klass);
-		Map<Field, Method> getters = eiHandler.getGetters(klass);
+		Set<Relationship> rs = EntityInfoHandler.getRelatedEntities(klass);
+		Map<Field, Method> getters = EntityInfoHandler.getGetters(klass);
 		for (Relationship r : rs) {
 			if (r.isCollection()) {
 				Method m = getters.get(r.getField());
@@ -342,16 +340,16 @@ public abstract class EntityBaseBean implements Serializable {
 			}
 		}
 		try {
-			Constructor<? extends EntityBaseBean> con = eiHandler.getConstructor(klass);
+			Constructor<? extends EntityBaseBean> con = EntityInfoHandler.getConstructor(klass);
 			EntityBaseBean clone = con.newInstance();
 			clone.id = this.id;
 			clone.createTime = this.createTime;
 			clone.createId = this.createId;
 			clone.modTime = this.modTime;
 			clone.modId = this.modId;
-			Set<Field> atts = eiHandler.getAttributes(klass);
-			Map<Field, Method> getters = eiHandler.getGetters(klass);
-			Map<Field, Method> setters = eiHandler.getSettersForUpdate(klass);
+			Set<Field> atts = EntityInfoHandler.getAttributes(klass);
+			Map<Field, Method> getters = EntityInfoHandler.getGetters(klass);
+			Map<Field, Method> setters = EntityInfoHandler.getSettersForUpdate(klass);
 			for (Field att : atts) {
 				Object value = getters.get(att).invoke(this);
 				if (value != null) {
@@ -359,7 +357,7 @@ public abstract class EntityBaseBean implements Serializable {
 				}
 			}
 			if (one) {
-				for (Relationship r : eiHandler.getOnes(klass)) {
+				for (Relationship r : EntityInfoHandler.getOnes(klass)) {
 					Field att = r.getField();
 					EntityBaseBean value = allowedOne(r, getters.get(att), gateKeeper, userId, manager);
 					if (value != null) {

--- a/src/main/java/org/icatproject/core/entity/PublicStep.java
+++ b/src/main/java/org/icatproject/core/entity/PublicStep.java
@@ -32,8 +32,6 @@ public class PublicStep extends EntityBaseBean implements Serializable {
 	public static final String GET_ALL_QUERY = "AllowedStep.GetAllQuery";
 	private static final Logger logger = LoggerFactory.getLogger(PublicStep.class);
 
-	private static final EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
-
 	public String getOrigin() {
 		return origin;
 	}
@@ -64,7 +62,7 @@ public class PublicStep extends EntityBaseBean implements Serializable {
 
 	private void fixup(EntityManager manager, GateKeeper gateKeeper) throws IcatException {
 		Class<? extends EntityBaseBean> bean = EntityInfoHandler.getClass(origin);
-		Set<Relationship> rs = eiHandler.getRelatedEntities(bean);
+		Set<Relationship> rs = EntityInfoHandler.getRelatedEntities(bean);
 		boolean found = false;
 		for (Relationship r : rs) {
 			if (r.getField().getName().equals(field)) {

--- a/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
+++ b/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
@@ -57,7 +57,6 @@ import jakarta.transaction.UserTransaction;
 import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.StreamingOutput;
 
-import org.icatproject.core.Constants;
 import org.icatproject.core.IcatException;
 import org.icatproject.core.IcatException.IcatExceptionType;
 import org.icatproject.core.entity.Datafile;
@@ -1528,11 +1527,9 @@ public class EntityBeanManager {
 
 	public void lucenePopulate(String entityName, long minid, EntityManager manager) throws IcatException {
 		if (luceneActive) {
-			try {
-				Class.forName(Constants.ENTITY_PREFIX + entityName);
-			} catch (ClassNotFoundException e) {
-				throw new IcatException(IcatExceptionType.BAD_PARAMETER, e.getMessage());
-			}
+			// Throws IcatException if entityName is not an ICAT entity
+			EntityInfoHandler.getClass(entityName);
+
 			lucene.populate(entityName, minid);
 		}
 	}

--- a/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
+++ b/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
@@ -115,8 +115,6 @@ public class EntityBeanManager {
 
 	private static DateFormat df = new SimpleDateFormat("yyyyMMddHHmmss");
 
-	private static EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
-
 	private static final Logger logger = LoggerFactory.getLogger(EntityBeanManager.class);
 
 	private static final Pattern timestampPattern = Pattern.compile(":ts(\\d{14})");
@@ -156,15 +154,15 @@ public class EntityBeanManager {
 	private String buildKey(EntityBaseBean bean, Map<String, Map<Long, String>> exportCaches)
 			throws IcatException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
 		Class<? extends EntityBaseBean> klass = bean.getClass();
-		List<Field> constraintFields = eiHandler.getConstraintFields(klass);
+		List<Field> constraintFields = EntityInfoHandler.getConstraintFields(klass);
 		if (constraintFields.isEmpty()) {
 			return '"' + bean.getId().toString() + '"';
 		}
-		List<Field> fields = eiHandler.getFields(klass);
-		Map<Field, Method> getters = eiHandler.getGetters(klass);
-		Map<String, Field> fieldMap = eiHandler.getFieldsByName(klass);
-		Set<Field> atts = eiHandler.getAttributes(klass);
-		Set<Field> updaters = eiHandler.getSettersForUpdate(klass).keySet();
+		List<Field> fields = EntityInfoHandler.getFields(klass);
+		Map<Field, Method> getters = EntityInfoHandler.getGetters(klass);
+		Map<String, Field> fieldMap = EntityInfoHandler.getFieldsByName(klass);
+		Set<Field> atts = EntityInfoHandler.getAttributes(klass);
+		Set<Field> updaters = EntityInfoHandler.getSettersForUpdate(klass).keySet();
 		StringBuilder sb = new StringBuilder();
 		boolean first = true;
 		for (Field field : fields) {
@@ -199,8 +197,8 @@ public class EntityBeanManager {
 	private boolean checkIdentityChange(EntityBaseBean thisBean, EntityBaseBean fromBean) throws IcatException {
 
 		Class<? extends EntityBaseBean> klass = thisBean.getClass();
-		Map<Field, Method> getters = eiHandler.getGetters(klass);
-		for (Field field : eiHandler.getRelInKey(klass)) {
+		Map<Field, Method> getters = EntityInfoHandler.getGetters(klass);
+		for (Field field : EntityInfoHandler.getRelInKey(klass)) {
 			try {
 				Method m = getters.get(field);
 				EntityBaseBean newValue = (EntityBaseBean) m.invoke(fromBean, new Object[0]);
@@ -415,9 +413,9 @@ public class EntityBeanManager {
 				 * Now look for duplicates within the list of objects provided
 				 */
 				Class<? extends EntityBaseBean> entityClass = bean.getClass();
-				Map<Field, Method> getters = eiHandler.getGetters(entityClass);
+				Map<Field, Method> getters = EntityInfoHandler.getGetters(entityClass);
 
-				List<Field> constraint = eiHandler.getConstraintFields(entityClass);
+				List<Field> constraint = EntityInfoHandler.getConstraintFields(entityClass);
 				if (!constraint.isEmpty()) {
 					for (int i = 0; i < pos; i++) {
 						boolean diff = false;
@@ -698,7 +696,7 @@ public class EntityBeanManager {
 				} else {
 					if (value == null) {
 						output.write(
-								eiHandler.getExportNull((Class<? extends EntityBaseBean>) field.getType()).getBytes());
+								EntityInfoHandler.getExportNull((Class<? extends EntityBaseBean>) field.getType()).getBytes());
 					} else {
 						long obId = ((EntityBaseBean) value).getId();
 						String obType = value.getClass().getSimpleName();
@@ -729,17 +727,17 @@ public class EntityBeanManager {
 		Class<? extends EntityBaseBean> klass = EntityInfoHandler.getClass(beanName);
 		output.write((linesep).getBytes());
 		if (allAttributes) {
-			output.write(eiHandler.getExportHeaderAll(klass).getBytes());
+			output.write(EntityInfoHandler.getExportHeaderAll(klass).getBytes());
 		} else {
-			output.write(eiHandler.getExportHeader(klass).getBytes());
+			output.write(EntityInfoHandler.getExportHeader(klass).getBytes());
 		}
 		output.write((linesep).getBytes());
-		List<Field> fields = eiHandler.getFields(klass);
-		Map<Field, Method> getters = eiHandler.getGetters(klass);
-		Map<String, Field> fieldMap = eiHandler.getFieldsByName(klass);
-		Set<Field> atts = eiHandler.getAttributes(klass);
-		Set<Field> updaters = eiHandler.getSettersForUpdate(klass).keySet();
-		boolean qcolumn = eiHandler.getConstraintFields(klass).isEmpty();
+		List<Field> fields = EntityInfoHandler.getFields(klass);
+		Map<Field, Method> getters = EntityInfoHandler.getGetters(klass);
+		Map<String, Field> fieldMap = EntityInfoHandler.getFieldsByName(klass);
+		Set<Field> atts = EntityInfoHandler.getAttributes(klass);
+		Set<Field> updaters = EntityInfoHandler.getSettersForUpdate(klass).keySet();
+		boolean qcolumn = EntityInfoHandler.getConstraintFields(klass).isEmpty();
 		boolean notRootUser = !rootUserNames.contains(userId);
 
 		if (ids == null) {
@@ -891,8 +889,8 @@ public class EntityBeanManager {
 
 	private List<EntityBaseBean> getDependentBeans(EntityBaseBean bean) throws IcatException {
 		Class<? extends EntityBaseBean> klass = bean.getClass();
-		Set<Relationship> rs = eiHandler.getRelatedEntities(klass);
-		Map<Field, Method> getters = eiHandler.getGetters(klass);
+		Set<Relationship> rs = EntityInfoHandler.getRelatedEntities(klass);
+		Map<Field, Method> getters = EntityInfoHandler.getGetters(klass);
 		List<EntityBaseBean> beans = new ArrayList<>();
 		for (Relationship r : rs) {
 			if (r.isCollection()) {
@@ -913,7 +911,7 @@ public class EntityBeanManager {
 	}
 
 	public EntityInfo getEntityInfo(String beanName) throws IcatException {
-		return eiHandler.getEntityInfo(beanName);
+		return EntityInfoHandler.getEntityInfo(beanName);
 	}
 
 	@SuppressWarnings("unchecked")
@@ -1187,8 +1185,8 @@ public class EntityBeanManager {
 
 		if (other != null) {
 			Class<? extends EntityBaseBean> entityClass = bean.getClass();
-			Map<Field, Method> getters = eiHandler.getGetters(entityClass);
-			List<Field> constraint = eiHandler.getConstraintFields(entityClass);
+			Map<Field, Method> getters = EntityInfoHandler.getGetters(entityClass);
+			List<Field> constraint = EntityInfoHandler.getConstraintFields(entityClass);
 
 			StringBuilder erm = new StringBuilder();
 			for (Field f : constraint) {
@@ -1213,8 +1211,8 @@ public class EntityBeanManager {
 	private void isValid(EntityBaseBean bean) throws IcatException {
 		logger.trace("Checking validity of {}", bean);
 		Class<? extends EntityBaseBean> klass = bean.getClass();
-		List<Field> notNullFields = eiHandler.getNotNullableFields(klass);
-		Map<Field, Method> getters = eiHandler.getGetters(klass);
+		List<Field> notNullFields = EntityInfoHandler.getNotNullableFields(klass);
+		Map<Field, Method> getters = EntityInfoHandler.getGetters(klass);
 
 		for (Field field : notNullFields) {
 
@@ -1232,7 +1230,7 @@ public class EntityBeanManager {
 			}
 		}
 
-		Map<Field, Integer> stringFields = eiHandler.getStringFields(klass);
+		Map<Field, Integer> stringFields = EntityInfoHandler.getStringFields(klass);
 		for (Entry<Field, Integer> entry : stringFields.entrySet()) {
 			Field field = entry.getKey();
 			Integer length = entry.getValue();
@@ -1341,8 +1339,8 @@ public class EntityBeanManager {
 	public EntityBaseBean lookup(EntityBaseBean bean, EntityManager manager) throws IcatException {
 		Class<? extends EntityBaseBean> entityClass = bean.getClass();
 
-		Map<Field, Method> getters = eiHandler.getGetters(entityClass);
-		List<Field> constraint = eiHandler.getConstraintFields(entityClass);
+		Map<Field, Method> getters = EntityInfoHandler.getGetters(entityClass);
+		List<Field> constraint = EntityInfoHandler.getConstraintFields(entityClass);
 		if (constraint.isEmpty()) {
 			return null;
 		}
@@ -1538,8 +1536,8 @@ public class EntityBeanManager {
 	// would be processed by JPA which gets confused by it.
 	private void merge(EntityBaseBean thisBean, Object fromBean, EntityManager manager) throws IcatException {
 		Class<? extends EntityBaseBean> klass = thisBean.getClass();
-		Map<Field, Method> setters = eiHandler.getSettersForUpdate(klass);
-		Map<Field, Method> getters = eiHandler.getGetters(klass);
+		Map<Field, Method> setters = EntityInfoHandler.getSettersForUpdate(klass);
+		Map<Field, Method> getters = EntityInfoHandler.getGetters(klass);
 
 		for (Entry<Field, Method> fieldAndMethod : setters.entrySet()) {
 			Field field = fieldAndMethod.getKey();
@@ -1569,12 +1567,12 @@ public class EntityBeanManager {
 	private void parseEntity(EntityBaseBean bean, JsonObject contents, Class<? extends EntityBaseBean> klass,
 			EntityManager manager, List<EntityBaseBean> creates, Map<EntityBaseBean, Boolean> localUpdates,
 			boolean create, String userId) throws IcatException {
-		Map<String, Field> fieldsByName = eiHandler.getFieldsByName(klass);
-		Set<Field> updaters = eiHandler.getSettersForUpdate(klass).keySet();
-		Map<Field, Method> setters = eiHandler.getSetters(klass);
-		Map<String, Relationship> rels = eiHandler.getRelationshipsByName(klass);
-		Map<String, Method> getters = eiHandler.getGettersFromName(klass);
-		Set<Field> relInKey = eiHandler.getRelInKey(klass);
+		Map<String, Field> fieldsByName = EntityInfoHandler.getFieldsByName(klass);
+		Set<Field> updaters = EntityInfoHandler.getSettersForUpdate(klass).keySet();
+		Map<Field, Method> setters = EntityInfoHandler.getSetters(klass);
+		Map<String, Relationship> rels = EntityInfoHandler.getRelationshipsByName(klass);
+		Map<String, Method> getters = EntityInfoHandler.getGettersFromName(klass);
+		Set<Field> relInKey = EntityInfoHandler.getRelInKey(klass);
 
 		boolean deleteAllowed = false;
 		if (!create) {
@@ -2141,8 +2139,8 @@ public class EntityBeanManager {
 			for (Entry<Class<? extends EntityBaseBean>, List<EntityBaseBean>> pair : beansByClass.entrySet()) {
 				Class<? extends EntityBaseBean> entityClass = pair.getKey();
 				List<EntityBaseBean> beans = pair.getValue();
-				Map<Field, Method> getters = eiHandler.getGetters(entityClass);
-				List<Field> constraint = eiHandler.getConstraintFields(entityClass);
+				Map<Field, Method> getters = EntityInfoHandler.getGetters(entityClass);
+				List<Field> constraint = EntityInfoHandler.getConstraintFields(entityClass);
 				if (!constraint.isEmpty()) {
 					for (EntityBaseBean bean1 : beans) {
 						for (EntityBaseBean bean2 : beans) {
@@ -2222,10 +2220,10 @@ public class EntityBeanManager {
 		}
 		Map<EntityBaseBean, EntityBaseBean> clonedTo = new HashMap<>();
 		clonedTo.put(bean, clone);
-		Map<Field, Method> setters = eiHandler.getSettersForUpdate(klass);
-		Map<Field, Method> getters = eiHandler.getGetters(klass);
-		List<Field> constraintFields = eiHandler.getConstraintFields(klass);
-		Set<Relationship> rs = eiHandler.getRelatedEntities(klass);
+		Map<Field, Method> setters = EntityInfoHandler.getSettersForUpdate(klass);
+		Map<Field, Method> getters = EntityInfoHandler.getGetters(klass);
+		List<Field> constraintFields = EntityInfoHandler.getConstraintFields(klass);
+		Set<Relationship> rs = EntityInfoHandler.getRelatedEntities(klass);
 
 		for (Entry<Field, Method> fieldAndMethod : setters.entrySet()) {
 			Field field = fieldAndMethod.getKey();
@@ -2400,9 +2398,9 @@ public class EntityBeanManager {
 							clonedCollection.add(subClone);
 							clonedTo.put(c, subClone);
 
-							Map<Field, Method> subSetters = eiHandler.getSettersForUpdate(subKlass);
-							Map<Field, Method> subGetters = eiHandler.getGetters(subKlass);
-							Set<Relationship> subRs = eiHandler.getRelatedEntities(subKlass);
+							Map<Field, Method> subSetters = EntityInfoHandler.getSettersForUpdate(subKlass);
+							Map<Field, Method> subGetters = EntityInfoHandler.getGetters(subKlass);
+							Set<Relationship> subRs = EntityInfoHandler.getRelatedEntities(subKlass);
 
 							for (Entry<Field, Method> fieldAndMethod : subSetters.entrySet()) {
 								Field field = fieldAndMethod.getKey();

--- a/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
+++ b/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
@@ -727,7 +727,7 @@ public class EntityBeanManager {
 			throws IcatException, IOException, IllegalAccessException, IllegalArgumentException,
 			InvocationTargetException {
 		logger.debug("Export " + (ids == null ? "complete" : "partial") + " " + beanName);
-		Class<EntityBaseBean> klass = EntityInfoHandler.getClass(beanName);
+		Class<? extends EntityBaseBean> klass = EntityInfoHandler.getClass(beanName);
 		output.write((linesep).getBytes());
 		if (allAttributes) {
 			output.write(eiHandler.getExportHeaderAll(klass).getBytes());
@@ -2057,7 +2057,7 @@ public class EntityBeanManager {
 
 		Entry<String, JsonValue> entry = entity.entrySet().iterator().next();
 		String beanName = entry.getKey();
-		Class<EntityBaseBean> klass = EntityInfoHandler.getClass(beanName);
+		Class<? extends EntityBaseBean> klass = EntityInfoHandler.getClass(beanName);
 		JsonValue value = entry.getValue();
 		if (value.getValueType() != ValueType.OBJECT) {
 			throw new IcatException(IcatExceptionType.BAD_PARAMETER,
@@ -2212,7 +2212,7 @@ public class EntityBeanManager {
 		long startMillis = log ? System.currentTimeMillis() : 0;
 		logger.info("{} cloning {}/{}", userId, beanName, id);
 
-		Class<EntityBaseBean> klass = EntityInfoHandler.getClass(beanName);
+		Class<? extends EntityBaseBean> klass = EntityInfoHandler.getClass(beanName);
 		EntityBaseBean bean = manager.find(klass, id);
 		if (bean == null) {
 			throw new IcatException(IcatExceptionType.NO_SUCH_OBJECT_FOUND, beanName + ":" + id);

--- a/src/main/java/org/icatproject/core/manager/EntityInfoHandler.java
+++ b/src/main/java/org/icatproject/core/manager/EntityInfoHandler.java
@@ -31,7 +31,6 @@ import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import jakarta.xml.bind.annotation.XmlTransient;
 
-import org.icatproject.core.Constants;
 import org.icatproject.core.IcatException;
 import org.icatproject.core.entity.Affiliation;
 import org.icatproject.core.entity.Application;
@@ -622,12 +621,8 @@ public class EntityInfoHandler {
 
 	@SuppressWarnings("unchecked")
 	public EntityInfo getEntityInfo(String beanName) throws IcatException {
-		Class<? extends EntityBaseBean> beanClass;
-		try {
-			beanClass = (Class<? extends EntityBaseBean>) Class.forName(Constants.ENTITY_PREFIX + beanName);
-		} catch (ClassNotFoundException e) {
-			throw new IcatException(IcatException.IcatExceptionType.BAD_PARAMETER, beanName + " is not an ICAT entity");
-		}
+		Class<? extends EntityBaseBean> beanClass = getClass(beanName);
+
 		EntityInfo entityInfo = new EntityInfo();
 		entityInfo.setClassComment(getClassComment(beanClass));
 		List<Field> constraint = getConstraintFields(beanClass);

--- a/src/main/java/org/icatproject/core/manager/EntityInfoHandler.java
+++ b/src/main/java/org/icatproject/core/manager/EntityInfoHandler.java
@@ -611,7 +611,6 @@ public class EntityInfoHandler {
 		return getPrivateEntityInfo(objectClass).constructor;
 	}
 
-	@SuppressWarnings("unchecked")
 	public static EntityInfo getEntityInfo(String beanName) throws IcatException {
 		Class<? extends EntityBaseBean> beanClass = getClass(beanName);
 

--- a/src/main/java/org/icatproject/core/manager/EntityInfoHandler.java
+++ b/src/main/java/org/icatproject/core/manager/EntityInfoHandler.java
@@ -234,27 +234,24 @@ public class EntityInfoHandler {
 	private static final List<String> ENTITY_NAMES =
 		ENTITIES.stream().map((entity) -> entity.getSimpleName()).sorted().collect(Collectors.toUnmodifiableList());
 
+	// Map of entity name -> entity class
+	private static final Map<String, Class<? extends EntityBaseBean>> ENTITY_NAME_MAP =
+		ENTITIES.stream().collect(Collectors.toUnmodifiableMap((entity) -> entity.getSimpleName(), (entity) -> entity));
+
 	// Map of entity class -> PrivateEntityInfo
 	private static final Map<Class<? extends EntityBaseBean>, PrivateEntityInfo> PRIVATE_ENTITY_INFO_MAP =
 		ENTITIES.stream().collect(Collectors.toUnmodifiableMap((entity) -> entity, (entity) -> buildEi(entity)));
 
 	private static EntityInfoHandler instance = new EntityInfoHandler();
 
-	public static Class<EntityBaseBean> getClass(String tableName) throws IcatException {
-		try {
-			final Class<?> klass = Class.forName(Constants.ENTITY_PREFIX + tableName);
-			if (EntityBaseBean.class.isAssignableFrom(klass)) {
-				@SuppressWarnings("unchecked")
-				final Class<EntityBaseBean> eklass = (Class<EntityBaseBean>) klass;
-				return eklass;
-			} else {
-				throw new IcatException(IcatException.IcatExceptionType.BAD_PARAMETER,
-						tableName + " is not an EntityBaseBean");
-			}
-		} catch (final ClassNotFoundException e) {
-			throw new IcatException(IcatException.IcatExceptionType.BAD_PARAMETER,
-					tableName + " is not an EntityBaseBean");
+	public static Class<? extends EntityBaseBean> getClass(String tableName) throws IcatException {
+		Class<? extends EntityBaseBean> entityClass = ENTITY_NAME_MAP.get(tableName);
+
+		if (entityClass == null) {
+			throw new IcatException(IcatException.IcatExceptionType.BAD_PARAMETER, tableName + " is not an ICAT entity");
 		}
+
+		return entityClass;
 	}
 
 	public static List<String> getEntityNamesList() {

--- a/src/main/java/org/icatproject/core/manager/EntityInfoHandler.java
+++ b/src/main/java/org/icatproject/core/manager/EntityInfoHandler.java
@@ -89,9 +89,7 @@ import org.icatproject.core.entity.UserGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-// Note that this does not use a Singleton Bean as there is no need for the
-// extra complexity and
-// that the instance is created statically as we know it will be needed.
+// This class only has static methods and cannot be instantiated
 public class EntityInfoHandler {
 
 	private static class PrivateEntityInfo {
@@ -241,8 +239,6 @@ public class EntityInfoHandler {
 	private static final Map<Class<? extends EntityBaseBean>, PrivateEntityInfo> PRIVATE_ENTITY_INFO_MAP =
 		ENTITIES.stream().collect(Collectors.toUnmodifiableMap((entity) -> entity, (entity) -> buildEi(entity)));
 
-	private static EntityInfoHandler instance = new EntityInfoHandler();
-
 	public static Class<? extends EntityBaseBean> getClass(String tableName) throws IcatException {
 		Class<? extends EntityBaseBean> entityClass = ENTITY_NAME_MAP.get(tableName);
 
@@ -260,10 +256,6 @@ public class EntityInfoHandler {
 	public static List<String> getExportEntityNames() {
 		return EXPORT_ENTITY_NAMES;
 	};
-
-	public static EntityInfoHandler getInstance() {
-		return instance;
-	}
 
 	private EntityInfoHandler() {
 	}
@@ -603,24 +595,24 @@ public class EntityInfoHandler {
 	 * Set of fields that are "simple attributes". This excludes relationships,
 	 * id, createId, CreateTime, modId and modTime
 	 */
-	public Set<Field> getAttributes(Class<? extends EntityBaseBean> objectClass) {
+	public static Set<Field> getAttributes(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).attributes;
 	}
 
-	public String getClassComment(Class<? extends EntityBaseBean> objectClass) {
+	public static String getClassComment(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).classComment;
 	}
 
-	public List<Field> getConstraintFields(Class<? extends EntityBaseBean> objectClass) {
+	public static List<Field> getConstraintFields(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).constraintFields;
 	}
 
-	public Constructor<? extends EntityBaseBean> getConstructor(Class<? extends EntityBaseBean> objectClass) {
+	public static Constructor<? extends EntityBaseBean> getConstructor(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).constructor;
 	}
 
 	@SuppressWarnings("unchecked")
-	public EntityInfo getEntityInfo(String beanName) throws IcatException {
+	public static EntityInfo getEntityInfo(String beanName) throws IcatException {
 		Class<? extends EntityBaseBean> beanClass = getClass(beanName);
 
 		EntityInfo entityInfo = new EntityInfo();
@@ -664,19 +656,19 @@ public class EntityInfoHandler {
 
 	}
 
-	public String getExportHeader(Class<? extends EntityBaseBean> objectClass) {
+	public static String getExportHeader(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).exportHeader;
 	}
 
-	public String getExportHeaderAll(Class<? extends EntityBaseBean> objectClass) {
+	public static String getExportHeaderAll(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).exportHeaderAll;
 	}
 
-	public String getExportNull(Class<? extends EntityBaseBean> objectClass) {
+	public static String getExportNull(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).exportNull;
 	}
 
-	public Map<Field, String> getFieldComments(Class<? extends EntityBaseBean> objectClass) {
+	public static Map<Field, String> getFieldComments(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).fieldComments;
 	}
 
@@ -684,25 +676,25 @@ public class EntityInfoHandler {
 	 * Returns all user settable fields (not id, createId, modId, createTime nor
 	 * modTime
 	 */
-	public List<Field> getFields(Class<? extends EntityBaseBean> objectClass) {
+	public static List<Field> getFields(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).fields;
 	}
 
-	public Map<String, Field> getFieldsByName(Class<? extends EntityBaseBean> objectClass) {
+	public static Map<String, Field> getFieldsByName(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).fieldsByName;
 	}
 
 	/**
 	 * Map from field to getter for all fields
 	 */
-	public Map<Field, Method> getGetters(Class<? extends EntityBaseBean> objectClass) {
+	public static Map<Field, Method> getGetters(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).getters;
 	}
 
 	/**
 	 * Map from field name to getter for all fields
 	 */
-	public Map<String, Method> getGettersFromName(Class<? extends EntityBaseBean> objectClass) {
+	public static Map<String, Method> getGettersFromName(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).gettersFromName;
 	}
 
@@ -725,15 +717,15 @@ public class EntityInfoHandler {
 		return fields;
 	}
 
-	public List<Field> getNotNullableFields(Class<? extends EntityBaseBean> objectClass) {
+	public static List<Field> getNotNullableFields(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).notNullableFields;
 	}
 
-	public Set<Relationship> getOnes(Class<? extends EntityBaseBean> objectClass) {
+	public static Set<Relationship> getOnes(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).ones;
 	}
 
-	public Set<Relationship> getRelatedEntities(Class<? extends EntityBaseBean> objectClass) {
+	public static Set<Relationship> getRelatedEntities(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).relatedEntities;
 	}
 
@@ -742,11 +734,11 @@ public class EntityInfoHandler {
 	 * 
 	 * @throws IcatException
 	 */
-	public Map<String, Relationship> getRelationshipsByName(Class<? extends EntityBaseBean> objectClass) {
+	public static Map<String, Relationship> getRelationshipsByName(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).relationshipsByName;
 	}
 
-	public Set<Field> getRelInKey(Class<? extends EntityBaseBean> objectClass) {
+	public static Set<Field> getRelInKey(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).relInKey;
 	}
 
@@ -754,7 +746,7 @@ public class EntityInfoHandler {
 	 * Map from field to setter for all fields including id but not for
 	 * createId, modId, createTime nor modTime
 	 */
-	public Map<Field, Method> getSetters(Class<? extends EntityBaseBean> objectClass) {
+	public static Map<Field, Method> getSetters(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).setters;
 	}
 
@@ -762,19 +754,19 @@ public class EntityInfoHandler {
 	 * Returns the setters for those fields that are not one to many
 	 * relationships and not id, createId, modId, createTime nor modTime
 	 */
-	public Map<Field, Method> getSettersForUpdate(Class<? extends EntityBaseBean> objectClass) {
+	public static Map<Field, Method> getSettersForUpdate(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).updaters;
 	}
 
 	/**
 	 * Returns all string fields except for createId and modId
 	 */
-	public Map<Field, Integer> getStringFields(Class<? extends EntityBaseBean> objectClass) {
+	public static Map<Field, Integer> getStringFields(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).stringFields;
 	}
 
 	/** Return true if getDoc() method exists else false */
-	public boolean hasLuceneDoc(Class<? extends EntityBaseBean> objectClass) {
+	public static boolean hasLuceneDoc(Class<? extends EntityBaseBean> objectClass) {
 		return getPrivateEntityInfo(objectClass).hasLuceneDoc;
 	}
 

--- a/src/main/java/org/icatproject/core/manager/EntityInfoHandler.java
+++ b/src/main/java/org/icatproject/core/manager/EntityInfoHandler.java
@@ -241,13 +241,6 @@ public class EntityInfoHandler {
 		Collections.sort(alphabeticEntityNames);
 	}
 
-	private final static Comparator<? super Field> fieldComparator = new Comparator<Field>() {
-		@Override
-		public int compare(Field o1, Field o2) {
-			return o1.getName().compareTo(o2.getName());
-		}
-	};
-
 	public static Set<String> getAlphabeticEntityNames() {
 		return entityNames;
 	}
@@ -296,7 +289,7 @@ public class EntityInfoHandler {
 			cobj = cobj.getSuperclass();
 		}
 
-		Collections.sort(fields, fieldComparator);
+		fields.sort(Comparator.comparing(Field::getName));
 		Map<String, Field> fieldsByName = new HashMap<>();
 
 		Set<Field> attributes = new HashSet<Field>();
@@ -824,7 +817,7 @@ public class EntityInfoHandler {
 			fields.addAll(getNormalFields(cobj));
 			cobj = cobj.getSuperclass();
 		}
-		Collections.sort(fields, fieldComparator);
+		fields.sort(Comparator.comparing(Field::getName));
 
 		String sep = "";
 		for (Field f : fields) {

--- a/src/main/java/org/icatproject/core/manager/EntityInfoHandler.java
+++ b/src/main/java/org/icatproject/core/manager/EntityInfoHandler.java
@@ -95,29 +95,29 @@ import org.slf4j.LoggerFactory;
 // that the instance is created statically as we know it will be needed.
 public class EntityInfoHandler {
 
-	private class PrivateEntityInfo {
+	private static class PrivateEntityInfo {
 
-		private Set<Field> attributes;
-		private String classComment;
-		private List<Field> constraintFields;
-		private Constructor<? extends EntityBaseBean> constructor;
-		public String exportHeader;
-		public String exportHeaderAll;
-		public String exportNull;
-		private Map<Field, String> fieldComments;
-		private Map<String, Field> fieldsByName;
-		private final Map<Field, Method> getters;
-		private final List<Field> notNullableFields;
-		private Set<Relationship> ones;
-		private final Set<Relationship> relatedEntities;
-		private Map<Field, Method> setters;
-		private final Map<Field, Integer> stringFields;
-		private final Map<Field, Method> updaters;
-		private List<Field> fields;
-		public Map<String, Method> gettersFromName;
-		public Map<String, Relationship> relationshipsByName;
-		public Set<Field> relInKey;
-		private boolean hasLuceneDoc;
+		final Set<Field> attributes;
+		final String classComment;
+		final List<Field> constraintFields;
+		final Constructor<? extends EntityBaseBean> constructor;
+		final String exportHeader;
+		final String exportHeaderAll;
+		final String exportNull;
+		final Map<Field, String> fieldComments;
+		final Map<String, Field> fieldsByName;
+		final Map<Field, Method> getters;
+		final List<Field> notNullableFields;
+		final Set<Relationship> ones;
+		final Set<Relationship> relatedEntities;
+		final Map<Field, Method> setters;
+		final Map<Field, Integer> stringFields;
+		final Map<Field, Method> updaters;
+		final List<Field> fields;
+		final Map<String, Method> gettersFromName;
+		final Map<String, Relationship> relationshipsByName;
+		final Set<Field> relInKey;
+		final boolean hasLuceneDoc;
 
 		public PrivateEntityInfo(Set<Relationship> rels, List<Field> notNullableFields, Map<Field, Method> getters,
 				Map<String, Method> gettersFromName, Map<Field, Integer> stringFields, Map<Field, Method> setters,
@@ -126,31 +126,33 @@ public class EntityInfoHandler {
 				Constructor<? extends EntityBaseBean> constructor, Map<String, Field> fieldByName, String exportHeader,
 				String exportNull, List<Field> fields, String exportHeaderAll,
 				Map<String, Relationship> relationshipsByName, Set<Field> relInKey, boolean hasLuceneDoc) {
-			this.relatedEntities = rels;
-			this.notNullableFields = notNullableFields;
-			this.getters = getters;
-			this.gettersFromName = gettersFromName;
-			this.stringFields = stringFields;
-			this.setters = setters;
-			this.updaters = updaters;
-			this.constraintFields = constraintFields;
+
+			// Use copyOf to create unmodifiable collections
+			this.relatedEntities = Set.copyOf(rels);
+			this.notNullableFields = List.copyOf(notNullableFields);
+			this.getters = Map.copyOf(getters);
+			this.gettersFromName = Map.copyOf(gettersFromName);
+			this.stringFields = Map.copyOf(stringFields);
+			this.setters = Map.copyOf(setters);
+			this.updaters = Map.copyOf(updaters);
+			this.constraintFields = List.copyOf(constraintFields);
 			this.classComment = classComment;
-			this.fieldComments = fieldComments;
-			this.ones = ones;
-			this.attributes = attributes;
+			this.fieldComments = Map.copyOf(fieldComments);
+			this.ones = Set.copyOf(ones);
+			this.attributes = Set.copyOf(attributes);
 			this.constructor = constructor;
-			this.fieldsByName = fieldByName;
+			this.fieldsByName = Map.copyOf(fieldByName);
 			this.exportHeader = exportHeader;
 			this.exportNull = exportNull;
-			this.fields = fields;
+			this.fields = List.copyOf(fields);
 			this.exportHeaderAll = exportHeaderAll;
-			this.relationshipsByName = relationshipsByName;
-			this.relInKey = relInKey;
+			this.relationshipsByName = Map.copyOf(relationshipsByName);
+			this.relInKey = Set.copyOf(relInKey);
 			this.hasLuceneDoc = hasLuceneDoc;
 		}
 	}
 
-	public class Relationship {
+	public static class Relationship {
 
 		private final boolean collection;
 
@@ -158,9 +160,9 @@ public class EntityInfoHandler {
 
 		private final Field field;
 
-		private Method inverseSetter;
+		private final Method inverseSetter;
 
-		private Class<? extends EntityBaseBean> originBean;
+		private final Class<? extends EntityBaseBean> originBean;
 
 		public Relationship(Class<? extends EntityBaseBean> originBean, Field field,
 				Class<? extends EntityBaseBean> destinationBean, boolean collection, boolean cascaded,

--- a/src/main/java/org/icatproject/core/manager/GateKeeper.java
+++ b/src/main/java/org/icatproject/core/manager/GateKeeper.java
@@ -68,8 +68,6 @@ public class GateKeeper {
 		}
 	};
 
-	private static final EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
-
 	private final static Pattern tsRegExp = Pattern
 			.compile("\\{\\s*ts\\s+\\d{4}-\\d{2}-\\d{2}\\s+\\d{2}:\\d{2}:\\d{2}\\s*\\}");
 
@@ -367,8 +365,8 @@ public class GateKeeper {
 		logger.info("Consider {}", contents);
 		Class<? extends EntityBaseBean> klass = bean.getClass();
 		String simpleName = klass.getSimpleName();
-		Set<Field> updaters = eiHandler.getSettersForUpdate(klass).keySet();
-		Map<String, Field> fieldsByName = eiHandler.getFieldsByName(klass);
+		Set<Field> updaters = EntityInfoHandler.getSettersForUpdate(klass).keySet();
+		Map<String, Field> fieldsByName = EntityInfoHandler.getFieldsByName(klass);
 
 		for (Entry<String, JsonValue> fentry : contents.entrySet()) {
 			String fName = fentry.getKey();

--- a/src/main/java/org/icatproject/core/manager/LuceneManager.java
+++ b/src/main/java/org/icatproject/core/manager/LuceneManager.java
@@ -129,7 +129,7 @@ public class LuceneManager {
 
 		@Override
 		public Long call() throws Exception {
-			if (eiHandler.hasLuceneDoc(klass)) {
+			if (EntityInfoHandler.hasLuceneDoc(klass)) {
 
 				URI uri = new URIBuilder(luceneApi.server).setPath(LuceneApi.basePath + "/addNow/" + entityName)
 						.build();
@@ -298,8 +298,6 @@ public class LuceneManager {
 		}
 	}
 
-	private static EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
-
 	final static Logger logger = LoggerFactory.getLogger(LuceneManager.class);
 
 	final static Marker fatal = MarkerFactory.getMarker("FATAL");
@@ -346,7 +344,7 @@ public class LuceneManager {
 
 	public void addDocument(EntityBaseBean bean) throws IcatException {
 		String entityName = bean.getClass().getSimpleName();
-		if (eiHandler.hasLuceneDoc(bean.getClass()) && entitiesToIndex.contains(entityName)) {
+		if (EntityInfoHandler.hasLuceneDoc(bean.getClass()) && entitiesToIndex.contains(entityName)) {
 			ByteArrayOutputStream baos = new ByteArrayOutputStream();
 			try (JsonGenerator gen = Json.createGenerator(baos)) {
 				gen.writeStartArray();
@@ -424,7 +422,7 @@ public class LuceneManager {
 	}
 
 	public void deleteDocument(EntityBaseBean bean) throws IcatException {
-		if (eiHandler.hasLuceneDoc(bean.getClass())) {
+		if (EntityInfoHandler.hasLuceneDoc(bean.getClass())) {
 			String entityName = bean.getClass().getSimpleName();
 			Long id = bean.getId();
 			enqueue(entityName, null, id);
@@ -539,7 +537,7 @@ public class LuceneManager {
 
 	public void updateDocument(EntityBaseBean bean) throws IcatException {
 		String entityName = bean.getClass().getSimpleName();
-		if (eiHandler.hasLuceneDoc(bean.getClass()) && entitiesToIndex.contains(entityName)) {
+		if (EntityInfoHandler.hasLuceneDoc(bean.getClass()) && entitiesToIndex.contains(entityName)) {
 			ByteArrayOutputStream baos = new ByteArrayOutputStream();
 			try (JsonGenerator gen = Json.createGenerator(baos)) {
 				gen.writeStartArray();

--- a/src/main/java/org/icatproject/core/manager/LuceneManager.java
+++ b/src/main/java/org/icatproject/core/manager/LuceneManager.java
@@ -46,7 +46,6 @@ import org.apache.http.client.utils.URIBuilder;
 import org.apache.http.entity.InputStreamEntity;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClients;
-import org.icatproject.core.Constants;
 import org.icatproject.core.IcatException;
 import org.icatproject.core.IcatException.IcatExceptionType;
 import org.icatproject.core.entity.EntityBaseBean;
@@ -118,7 +117,7 @@ public class LuceneManager {
 			try {
 				logger.debug("About to index {} {} records", ids.size(), entityName);
 				this.entityName = entityName;
-				klass = (Class<? extends EntityBaseBean>) Class.forName(Constants.ENTITY_PREFIX + entityName);
+				klass = EntityInfoHandler.getClass(entityName);
 				this.ids = ids;
 				manager = entityManagerFactory.createEntityManager();
 				this.start = start;

--- a/src/main/java/org/icatproject/core/manager/NotificationMessage.java
+++ b/src/main/java/org/icatproject/core/manager/NotificationMessage.java
@@ -34,12 +34,6 @@ public class NotificationMessage {
 		}
 	}
 
-	private final static EntityInfoHandler entityInfoHandler = EntityInfoHandler.getInstance();
-
-	public static EntityInfoHandler getEntityinfohandler() {
-		return entityInfoHandler;
-	}
-
 	private Message message;
 
 	public NotificationMessage(Operation operation, EntityBaseBean bean, EntityManager manager,

--- a/src/main/java/org/icatproject/core/manager/Porter.java
+++ b/src/main/java/org/icatproject/core/manager/Porter.java
@@ -94,8 +94,6 @@ public class Porter {
 	private final static DateFormat dfZoned = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssXXX");
 	private final static DateFormat dfNoZone = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
 
-	private final static EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
-
 	@PostConstruct
 	void init() {
 		importCacheSize = propertyHandler.getImportCacheSize();
@@ -492,9 +490,9 @@ public class Porter {
 
 						}
 						Class<? extends EntityBaseBean> klass = bean.getClass();
-						Map<Field, Method> getters = eiHandler.getGetters(klass);
-						Set<Field> updaters = eiHandler.getSettersForUpdate(klass).keySet();
-						for (Field f : eiHandler.getFields(klass)) {
+						Map<Field, Method> getters = EntityInfoHandler.getGetters(klass);
+						Set<Field> updaters = EntityInfoHandler.getSettersForUpdate(klass).keySet();
+						for (Field f : EntityInfoHandler.getFields(klass)) {
 							if (updaters.contains(f)) {
 								if (EntityBaseBean.class.isAssignableFrom(f.getType())) {
 									EntityBaseBean beanField = (EntityBaseBean) getters.get(f).invoke(bean);

--- a/src/main/java/org/icatproject/core/manager/PropertyHandler.java
+++ b/src/main/java/org/icatproject/core/manager/PropertyHandler.java
@@ -403,10 +403,9 @@ public class PropertyHandler {
 				String notificationList = props.getString(key);
 				formattedProps.add(key + " " + notificationList);
 
-				EntityInfoHandler ei = EntityInfoHandler.getInstance();
 				for (String entity : notificationList.split("\\s+")) {
 					try {
-						ei.getEntityInfo(entity);
+						EntityInfoHandler.getEntityInfo(entity);
 					} catch (IcatException e) {
 						String msg = "Value '" + entity + "' specified in 'notification.list' is not an ICAT entity";
 						logger.error(fatal, msg);

--- a/src/main/java/org/icatproject/core/manager/importParser/AttWithOptParenList.java
+++ b/src/main/java/org/icatproject/core/manager/importParser/AttWithOptParenList.java
@@ -21,7 +21,6 @@ public class AttWithOptParenList {
 	private String joins = "";
 	private List<String> wheres;
 	private List<Attribute> attributes;
-	private final static EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
 
 	@SuppressWarnings("unchecked")
 	public AttWithOptParenList(Input input, Class<EntityBaseBean> entityClass,
@@ -38,7 +37,7 @@ public class AttWithOptParenList {
 		if (nextT == Token.Type.OPENPAREN) {
 			entityClass = (Class<EntityBaseBean>) field.getType();
 			parenAttList = new ParenAttList(input, entityClass,
-					eiHandler.getFieldsByName(entityClass), eiHandler.getSetters(entityClass),
+					EntityInfoHandler.getFieldsByName(entityClass), EntityInfoHandler.getSetters(entityClass),
 					parentName + relName);
 			joins = " JOIN " + parentName + "." + attribute + " " + parentName + relName
 					+ parenAttList.getJoins();

--- a/src/main/java/org/icatproject/core/manager/importParser/Table.java
+++ b/src/main/java/org/icatproject/core/manager/importParser/Table.java
@@ -17,7 +17,7 @@ public class Table {
 
 	private String name;
 	private List<TableField> tableFields = new ArrayList<>();
-	private Class<EntityBaseBean> tableClass;
+	private Class<? extends EntityBaseBean> tableClass;
 	private final static EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
 
 	public Table(Input input) throws ParserException, IcatException {

--- a/src/main/java/org/icatproject/core/manager/importParser/Table.java
+++ b/src/main/java/org/icatproject/core/manager/importParser/Table.java
@@ -18,13 +18,12 @@ public class Table {
 	private String name;
 	private List<TableField> tableFields = new ArrayList<>();
 	private Class<? extends EntityBaseBean> tableClass;
-	private final static EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
 
 	public Table(Input input) throws ParserException, IcatException {
 		name = input.consume(Token.Type.NAME).getValue();
 		tableClass = EntityInfoHandler.getClass(name);
-		Map<String, Field> fieldsByName = eiHandler.getFieldsByName(tableClass);
-		Map<Field, Method> setters = eiHandler.getSetters(tableClass);
+		Map<String, Field> fieldsByName = EntityInfoHandler.getFieldsByName(tableClass);
+		Map<Field, Method> setters = EntityInfoHandler.getSetters(tableClass);
 
 		input.consume(Token.Type.OPENPAREN);
 		while (true) {

--- a/src/main/java/org/icatproject/core/manager/importParser/TableField.java
+++ b/src/main/java/org/icatproject/core/manager/importParser/TableField.java
@@ -46,7 +46,7 @@ public class TableField {
 	}
 
 	@SuppressWarnings("unchecked")
-	public TableField(Input input, Class<EntityBaseBean> tableClass,
+	public TableField(Input input, Class<? extends EntityBaseBean> tableClass,
 			Map<String, Field> fieldsByName, Map<Field, Method> setters) throws ParserException,
 			IcatException {
 		Token next = input.consume(Token.Type.NAME, Token.Type.QMARK);

--- a/src/main/java/org/icatproject/core/manager/importParser/TableField.java
+++ b/src/main/java/org/icatproject/core/manager/importParser/TableField.java
@@ -26,7 +26,6 @@ public class TableField {
 	private String jpql;
 	private List<Attribute> attributes;
 	private boolean qmark;
-	private final static EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
 
 	private static Map<String, Method> systemSetters = new HashMap<>();
 
@@ -84,7 +83,7 @@ public class TableField {
 			} else {
 				Class<EntityBaseBean> entityClass = (Class<EntityBaseBean>) field.getType();
 				parenAttlist = new ParenAttList(input, entityClass,
-						eiHandler.getFieldsByName(entityClass), eiHandler.getSetters(tableClass),
+						EntityInfoHandler.getFieldsByName(entityClass), EntityInfoHandler.getSetters(tableClass),
 						"n0");
 				StringBuilder sb = new StringBuilder("SELECT n0 FROM "
 						+ entityClass.getSimpleName() + " n0" + parenAttlist.getJoins());

--- a/src/main/java/org/icatproject/core/oldparser/DagHandler.java
+++ b/src/main/java/org/icatproject/core/oldparser/DagHandler.java
@@ -15,8 +15,6 @@ import org.icatproject.core.manager.EntityInfoHandler.Relationship;
  */
 public class DagHandler {
 
-	private static EntityInfoHandler pkHandler = EntityInfoHandler.getInstance();
-
 	/**
 	 * A nested structure with a bean a relationship and the set of steps. It is a set because there
 	 * may be a need to follow more than one chain of entities.
@@ -114,7 +112,7 @@ public class DagHandler {
 			Class<? extends EntityBaseBean> from, Set<Class<? extends EntityBaseBean>> allBeans,
 			Set<Class<? extends EntityBaseBean>> used) throws IcatException {
 		Set<Step> steps = new HashSet<Step>();
-		Set<Relationship> navto = pkHandler.getRelatedEntities(from);
+		Set<Relationship> navto = EntityInfoHandler.getRelatedEntities(from);
 		for (Relationship relationship : navto) {
 			Class<? extends EntityBaseBean> bean = relationship.getDestinationBean();
 			if (allBeans.contains(bean) && !bean.equals(predecessor)) {
@@ -167,7 +165,7 @@ public class DagHandler {
 			Class<? extends EntityBaseBean> from, Set<Class<? extends EntityBaseBean>> allBeans,
 			Set<Class<? extends EntityBaseBean>> used, boolean followCascades) throws IcatException {
 		Set<Step> steps = new HashSet<Step>();
-		Set<Relationship> navto = pkHandler.getRelatedEntities(from);
+		Set<Relationship> navto = EntityInfoHandler.getRelatedEntities(from);
 		for (Relationship relationship : navto) {
 			if (!relationship.isCollection() || followCascades) {
 				Class<? extends EntityBaseBean> bean = relationship.getDestinationBean();

--- a/src/main/java/org/icatproject/core/oldparser/OldInclude.java
+++ b/src/main/java/org/icatproject/core/oldparser/OldInclude.java
@@ -22,8 +22,6 @@ public class OldInclude {
 		FIRST, LOWER
 	};
 
-	private static EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
-
 	private Set<Class<? extends EntityBaseBean>> includes = new HashSet<Class<? extends EntityBaseBean>>();
 
 	static Logger logger = LoggerFactory.getLogger(OldInclude.class);
@@ -72,7 +70,7 @@ public class OldInclude {
 					throws IcatException {
 		boolean first = position == Position.FIRST;
 		String suffix = first ? "$" : "_$";
-		Set<Relationship> relationships = eiHandler.getRelatedEntities(entityClass);
+		Set<Relationship> relationships = EntityInfoHandler.getRelatedEntities(entityClass);
 		for (Relationship r : relationships) {
 			if (!r.isCollection() || followCascades == FollowCascades.TRUE) {
 				Class<? extends EntityBaseBean> bean = r.getDestinationBean();

--- a/src/main/java/org/icatproject/core/parser/FromClause.java
+++ b/src/main/java/org/icatproject/core/parser/FromClause.java
@@ -50,7 +50,7 @@ public class FromClause {
 			String val = t.getValue();
 			sb.append(" " + val);
 			if (t.getType() == Token.Type.NAME) {
-				if (EntityInfoHandler.getAlphabeticEntityNames().contains(val)) {
+				if (EntityInfoHandler.getEntityNamesList().contains(val)) {
 					currentEntity = EntityInfoHandler.getClass(val);
 				} else {
 					int dot = val.indexOf('.');

--- a/src/main/java/org/icatproject/core/parser/FromClause.java
+++ b/src/main/java/org/icatproject/core/parser/FromClause.java
@@ -17,8 +17,6 @@ import org.slf4j.LoggerFactory;
 
 public class FromClause {
 
-	private static final EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
-
 	private String clause;
 
 	private Map<String, Class<? extends EntityBaseBean>> authzMap = new HashMap<>();
@@ -72,7 +70,7 @@ public class FromClause {
 							int dotn = val.indexOf(".", dot + 1);
 							String relPath = dotn < 0 ? val.substring(dot + 1) : val.substring(dot + 1, dotn);
 
-							Relationship r = eiHandler.getRelationshipsByName(currentEntity).get(relPath);
+							Relationship r = EntityInfoHandler.getRelationshipsByName(currentEntity).get(relPath);
 							if (r == null) {
 								throw new ParserException(
 										currentEntity.getSimpleName() + " has no relationship field " + relPath);
@@ -107,7 +105,7 @@ public class FromClause {
 				int dotn = idPath.indexOf(".", dot + 1);
 				String relPath = dotn < 0 ? idPath.substring(dot + 1) : idPath.substring(dot + 1, dotn);
 
-				Field f = eiHandler.getFieldsByName(bean).get(relPath);
+				Field f = EntityInfoHandler.getFieldsByName(bean).get(relPath);
 				if (f == null) {
 					throw new ParserException(bean.getSimpleName() + " has no field " + relPath);
 				}

--- a/src/main/java/org/icatproject/core/parser/IncludeClause.java
+++ b/src/main/java/org/icatproject/core/parser/IncludeClause.java
@@ -27,7 +27,7 @@ public class IncludeClause {
 
 		public Step(int hereVarNum, String fieldName, int thereVarNum, GateKeeper gateKeeper, Set<String> keys)
 				throws IcatException, ParserException {
-			for (Relationship r : eiHandler.getRelatedEntities(types.get(hereVarNum))) {
+			for (Relationship r : EntityInfoHandler.getRelatedEntities(types.get(hereVarNum))) {
 				if (r.getField().getName().equals(fieldName)) {
 					types.put(thereVarNum, r.getDestinationBean());
 					relationship = r;
@@ -66,8 +66,6 @@ public class IncludeClause {
 		}
 
 	}
-
-	private static final EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
 
 	static Logger logger = LoggerFactory.getLogger(IncludeClause.class);
 

--- a/src/main/java/org/icatproject/core/parser/RuleWhat.java
+++ b/src/main/java/org/icatproject/core/parser/RuleWhat.java
@@ -25,8 +25,6 @@ public class RuleWhat {
 
 	private Pattern idPattern = Pattern.compile("^[a-zA-Z_$]([\\w_$])*$");
 
-	EntityInfoHandler ei = EntityInfoHandler.getInstance();
-
 	public RuleWhat(String query) throws ParserException, IcatException {
 		List<Token> tokens;
 		try {
@@ -56,7 +54,7 @@ public class RuleWhat {
 
 		if (offset > 0) {
 			Class<? extends EntityBaseBean> bean = fromClause.getAuthzMap().get(idVar + ".id");
-			if (ei.getFieldsByName(bean).get(attribute) == null) {
+			if (EntityInfoHandler.getFieldsByName(bean).get(attribute) == null) {
 				throw new ParserException(bean + " does not have attribute " + attribute);
 			}
 		}

--- a/src/main/java/org/icatproject/exposed/ICATRest.java
+++ b/src/main/java/org/icatproject/exposed/ICATRest.java
@@ -303,7 +303,7 @@ public class ICATRest {
 		}
 		Entry<String, JsonValue> entry = entity.entrySet().iterator().next();
 		String beanName = entry.getKey();
-		Class<EntityBaseBean> klass = EntityInfoHandler.getClass(beanName);
+		Class<? extends EntityBaseBean> klass = EntityInfoHandler.getClass(beanName);
 		JsonObject contents = (JsonObject) entry.getValue();
 
 		EntityBaseBean bean = null;

--- a/src/main/java/org/icatproject/exposed/ICATRest.java
+++ b/src/main/java/org/icatproject/exposed/ICATRest.java
@@ -111,8 +111,6 @@ public class ICATRest {
 		}
 	}
 
-	private static EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
-
 	private Map<String, ExtendedAuthenticator> authPlugins;
 
 	@EJB
@@ -724,11 +722,11 @@ public class ICATRest {
 		}
 
 		Class<? extends EntityBaseBean> klass = bean.getClass();
-		Map<Field, Method> getters = eiHandler.getGetters(klass);
-		Set<Field> atts = eiHandler.getAttributes(klass);
-		Set<Field> updaters = eiHandler.getSettersForUpdate(klass).keySet();
+		Map<Field, Method> getters = EntityInfoHandler.getGetters(klass);
+		Set<Field> atts = EntityInfoHandler.getAttributes(klass);
+		Set<Field> updaters = EntityInfoHandler.getSettersForUpdate(klass).keySet();
 
-		for (Field field : eiHandler.getFields(klass)) {
+		for (Field field : EntityInfoHandler.getFields(klass)) {
 			Object value = null;
 			try {
 				value = getters.get(field).invoke(bean);

--- a/src/test/java/org/icatproject/core/manager/TestEntityInfo.java
+++ b/src/test/java/org/icatproject/core/manager/TestEntityInfo.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.icatproject.core.Constants;
 import org.icatproject.core.IcatException;
 import org.icatproject.core.entity.DataCollection;
 import org.icatproject.core.entity.DataCollectionDatafile;
@@ -50,8 +49,7 @@ public class TestEntityInfo {
 				"InvestigationParameter", "DatasetParameter", "DatafileParameter", "InvestigationUser", "Sample"));
 		for (String beanName : EntityInfoHandler.getEntityNamesList()) {
 			@SuppressWarnings("unchecked")
-			Class<? extends EntityBaseBean> bean = (Class<? extends EntityBaseBean>) Class
-					.forName(Constants.ENTITY_PREFIX + beanName);
+			Class<? extends EntityBaseBean> bean = EntityInfoHandler.getClass(beanName);
 			if (docdbeans.contains(beanName)) {
 				assertTrue(eiHandler.hasLuceneDoc(bean));
 			} else {

--- a/src/test/java/org/icatproject/core/manager/TestEntityInfo.java
+++ b/src/test/java/org/icatproject/core/manager/TestEntityInfo.java
@@ -36,11 +36,9 @@ import org.junit.Test;
 
 public class TestEntityInfo {
 
-	private static EntityInfoHandler eiHandler = EntityInfoHandler.getInstance();
-
 	@Test(expected = IcatException.class)
 	public void testBadname() throws Exception {
-		eiHandler.getEntityInfo("Fred");
+		EntityInfoHandler.getEntityInfo("Fred");
 	}
 
 	@Test
@@ -51,9 +49,9 @@ public class TestEntityInfo {
 			@SuppressWarnings("unchecked")
 			Class<? extends EntityBaseBean> bean = EntityInfoHandler.getClass(beanName);
 			if (docdbeans.contains(beanName)) {
-				assertTrue(eiHandler.hasLuceneDoc(bean));
+				assertTrue(EntityInfoHandler.hasLuceneDoc(bean));
 			} else {
-				assertFalse(eiHandler.hasLuceneDoc(bean));
+				assertFalse(EntityInfoHandler.hasLuceneDoc(bean));
 			}
 		}
 	}
@@ -61,38 +59,38 @@ public class TestEntityInfo {
 	@Test
 	public void testExportHeaders() throws Exception {
 		assertEquals("Facility(daysUntilRelease:0,description:1,fullName:2,name:3,url:4)",
-				eiHandler.getExportHeader(Facility.class));
+				EntityInfoHandler.getExportHeader(Facility.class));
 		assertEquals("InvestigationType(description:0,facility(name:1),name:2)",
-				eiHandler.getExportHeader(InvestigationType.class));
+				EntityInfoHandler.getExportHeader(InvestigationType.class));
 		assertEquals(
 				"Investigation(doi:0,endDate:1,facility(name:2),fileCount:3,fileSize:4,name:5,releaseDate:6,"
 						+ "startDate:7,summary:8,title:9,type(facility(name:10),name:11),visitId:12)",
-				eiHandler.getExportHeader(Investigation.class));
+				EntityInfoHandler.getExportHeader(Investigation.class));
 		assertEquals(
 				"Dataset(complete:0,description:1,doi:2,endDate:3,fileCount:4,fileSize:5,investigation(facility(name:6),"
 						+ "name:7,visitId:8),location:9,name:10,sample(investigation(facility(name:11),"
 						+ "name:12,visitId:13),name:14),startDate:15,type(facility(name:16),name:17))",
-				eiHandler.getExportHeader(Dataset.class));
-		assertEquals("DataCollection(?:0,doi:1)", eiHandler.getExportHeader(DataCollection.class));
+				EntityInfoHandler.getExportHeader(Dataset.class));
+		assertEquals("DataCollection(?:0,doi:1)", EntityInfoHandler.getExportHeader(DataCollection.class));
 		assertEquals(
 				"Job(?:0,application(facility(name:1),name:2,version:3),arguments:4,inputDataCollection(?:5),outputDataCollection(?:6))",
-				eiHandler.getExportHeader(Job.class));
+				EntityInfoHandler.getExportHeader(Job.class));
 		assertEquals( "Study(?:0,description:1,endDate:2,name:3,pid:4,startDate:5,status:6,user(name:7))",
-				eiHandler.getExportHeader(Study.class));
+				EntityInfoHandler.getExportHeader(Study.class));
 		assertEquals(
 				"DatasetParameter(dataset(investigation(facility(name:0),name:1,visitId:2),name:3),"
 						+ "dateTimeValue:4,error:5,numericValue:6,rangeBottom:7,rangeTop:8,stringValue:9,"
 						+ "type(facility(name:10),name:11,units:12))",
-				eiHandler.getExportHeader(DatasetParameter.class));
+				EntityInfoHandler.getExportHeader(DatasetParameter.class));
 		assertEquals("ParameterType(applicableToDataCollection:0,applicableToDatafile:1,applicableToDataset:2,"
 				+ "applicableToInvestigation:3,applicableToSample:4,description:5,enforced:6,facility(name:7),"
 				+ "maximumNumericValue:8,minimumNumericValue:9,name:10,pid:11,units:12,unitsFullName:13,"
-				+ "valueType:14,verified:15)", eiHandler.getExportHeader(ParameterType.class));
-		assertEquals("DataCollection(?:0,doi:1)", eiHandler.getExportHeader(DataCollection.class));
-		assertEquals("Rule(?:0,crudFlags:1,grouping(name:2),what:3)", eiHandler.getExportHeader(Rule.class));
+				+ "valueType:14,verified:15)", EntityInfoHandler.getExportHeader(ParameterType.class));
+		assertEquals("DataCollection(?:0,doi:1)", EntityInfoHandler.getExportHeader(DataCollection.class));
+		assertEquals("Rule(?:0,crudFlags:1,grouping(name:2),what:3)", EntityInfoHandler.getExportHeader(Rule.class));
 		assertEquals(
 				"DataCollectionDatafile(dataCollection(?:0),datafile(dataset(investigation(facility(name:1),name:2,visitId:3),name:4),name:5))",
-				eiHandler.getExportHeader(DataCollectionDatafile.class));
+				EntityInfoHandler.getExportHeader(DataCollectionDatafile.class));
 	}
 
 	@Test
@@ -100,38 +98,38 @@ public class TestEntityInfo {
 		assertEquals(
 				"Facility(createId:0,createTime:1,modId:2,"
 						+ "modTime:3,daysUntilRelease:4,description:5,fullName:6,name:7,url:8)",
-				eiHandler.getExportHeaderAll(Facility.class));
+				EntityInfoHandler.getExportHeaderAll(Facility.class));
 		assertEquals(
 				"InvestigationType(createId:0,createTime:1,modId:2,"
 						+ "modTime:3,description:4,facility(name:5),name:6)",
-				eiHandler.getExportHeaderAll(InvestigationType.class));
+				EntityInfoHandler.getExportHeaderAll(InvestigationType.class));
 		assertEquals(
 				"Investigation(createId:0,createTime:1,modId:2,modTime:3,"
 						+ "doi:4,endDate:5,facility(name:6),fileCount:7,fileSize:8,name:9,releaseDate:10,"
 						+ "startDate:11,summary:12,title:13,type(facility(name:14),name:15),visitId:16)",
-				eiHandler.getExportHeaderAll(Investigation.class));
+				EntityInfoHandler.getExportHeaderAll(Investigation.class));
 		assertEquals(
 				"Dataset(createId:0,createTime:1,modId:2,modTime:3,"
 						+ "complete:4,description:5,doi:6,endDate:7,fileCount:8,fileSize:9,"
 						+ "investigation(facility(name:10),name:11,visitId:12),location:13,name:14,"
 						+ "sample(investigation(facility(name:15),name:16,visitId:17),"
 						+ "name:18),startDate:19,type(facility(name:20),name:21))",
-				eiHandler.getExportHeaderAll(Dataset.class));
+				EntityInfoHandler.getExportHeaderAll(Dataset.class));
 		assertEquals("DataCollection(?:0,createId:1,createTime:2,modId:3,modTime:4,doi:5)",
-				eiHandler.getExportHeaderAll(DataCollection.class));
+				EntityInfoHandler.getExportHeaderAll(DataCollection.class));
 		assertEquals(
 				"Job(?:0,createId:1,createTime:2,modId:3,modTime:4,"
 						+ "application(facility(name:5),name:6,version:7),arguments:8,"
 						+ "inputDataCollection(?:9),outputDataCollection(?:10))",
-				eiHandler.getExportHeaderAll(Job.class));
+				EntityInfoHandler.getExportHeaderAll(Job.class));
 		assertEquals( "Study(?:0,description:1,endDate:2,name:3,pid:4,startDate:5,status:6,user(name:7))",
-				eiHandler.getExportHeader(Study.class));
+				EntityInfoHandler.getExportHeader(Study.class));
 		assertEquals(
 				"DatasetParameter(createId:0,createTime:1,modId:2,modTime:3,"
 						+ "dataset(investigation(facility(name:4),name:5,visitId:6),name:7),"
 						+ "dateTimeValue:8,error:9,numericValue:10,rangeBottom:11,"
 						+ "rangeTop:12,stringValue:13,type(facility(name:14),name:15,units:16))",
-				eiHandler.getExportHeaderAll(DatasetParameter.class));
+				EntityInfoHandler.getExportHeaderAll(DatasetParameter.class));
 		assertEquals(
 				"ParameterType(createId:0,createTime:1,modId:2,modTime:3,"
 						+ "applicableToDataCollection:4,applicableToDatafile:5,"
@@ -139,27 +137,27 @@ public class TestEntityInfo {
 						+ "applicableToSample:8,description:9,enforced:10,facility(name:11),"
 						+ "maximumNumericValue:12,minimumNumericValue:13,name:14,pid:15,"
 						+ "units:16,unitsFullName:17,valueType:18,verified:19)",
-				eiHandler.getExportHeaderAll(ParameterType.class));
-		assertEquals("DataCollection(?:0,doi:1)", eiHandler.getExportHeader(DataCollection.class));
+				EntityInfoHandler.getExportHeaderAll(ParameterType.class));
+		assertEquals("DataCollection(?:0,doi:1)", EntityInfoHandler.getExportHeader(DataCollection.class));
 		assertEquals("Rule(?:0,createId:1,createTime:2,modId:3,modTime:4," + "crudFlags:5,grouping(name:6),what:7)",
-				eiHandler.getExportHeaderAll(Rule.class));
+				EntityInfoHandler.getExportHeaderAll(Rule.class));
 		assertEquals(
 				"DataCollectionDatafile(createId:0,createTime:1,modId:2,modTime:3,"
 						+ "dataCollection(?:4),datafile(dataset(investigation(facility(name:5),"
 						+ "name:6,visitId:7),name:8),name:9))",
-				eiHandler.getExportHeaderAll(DataCollectionDatafile.class));
+				EntityInfoHandler.getExportHeaderAll(DataCollectionDatafile.class));
 	}
 
 	@Test
 	public void testExportNull() throws Exception {
-		assertEquals("NULL", eiHandler.getExportNull(Facility.class));
-		assertEquals("NULL,NA", eiHandler.getExportNull(InvestigationType.class));
-		assertEquals("NULL,NA,NA", eiHandler.getExportNull(Investigation.class));
-		assertEquals("NULL,NA,NA,NA", eiHandler.getExportNull(Dataset.class));
-		assertEquals("", eiHandler.getExportNull(DataCollection.class));
-		assertEquals("", eiHandler.getExportNull(Job.class));
-		assertEquals("NULL,NA,NA,NA,NA,NA,NA", eiHandler.getExportNull(DatasetParameter.class));
-		assertEquals("NULL,NA,NA", eiHandler.getExportNull(ParameterType.class));
+		assertEquals("NULL", EntityInfoHandler.getExportNull(Facility.class));
+		assertEquals("NULL,NA", EntityInfoHandler.getExportNull(InvestigationType.class));
+		assertEquals("NULL,NA,NA", EntityInfoHandler.getExportNull(Investigation.class));
+		assertEquals("NULL,NA,NA,NA", EntityInfoHandler.getExportNull(Dataset.class));
+		assertEquals("", EntityInfoHandler.getExportNull(DataCollection.class));
+		assertEquals("", EntityInfoHandler.getExportNull(Job.class));
+		assertEquals("NULL,NA,NA,NA,NA,NA,NA", EntityInfoHandler.getExportNull(DatasetParameter.class));
+		assertEquals("NULL,NA,NA", EntityInfoHandler.getExportNull(ParameterType.class));
 	}
 
 	@Test
@@ -191,7 +189,7 @@ public class TestEntityInfo {
 	private void testField(String result, Class<? extends EntityBaseBean> klass) throws Exception {
 		String sep = "";
 		StringBuilder sb = new StringBuilder();
-		for (Field f : eiHandler.getFields(klass)) {
+		for (Field f : EntityInfoHandler.getFields(klass)) {
 			sb.append(sep + f.getName());
 			sep = ",";
 		}
@@ -209,7 +207,7 @@ public class TestEntityInfo {
 	}
 
 	private void testConstraint(Class<? extends EntityBaseBean> klass, String... name) throws Exception {
-		List<Field> result = eiHandler.getConstraintFields(klass);
+		List<Field> result = EntityInfoHandler.getConstraintFields(klass);
 		if (name.length == 0) {
 			assertEquals("One", 0, result.size());
 		} else {
@@ -225,7 +223,7 @@ public class TestEntityInfo {
 
 	@Test
 	public void testFieldByName() throws Exception {
-		Map<String, Field> fields = eiHandler.getFieldsByName(EntityInfoHandler.getClass("DatafileParameter"));
+		Map<String, Field> fields = EntityInfoHandler.getFieldsByName(EntityInfoHandler.getClass("DatafileParameter"));
 		assertEquals("protected java.lang.Long org.icatproject.core.entity.EntityBaseBean.id",
 				fields.get("id").toString());
 		assertEquals(
@@ -283,7 +281,7 @@ public class TestEntityInfo {
 	}
 
 	private void testRel(Class<? extends EntityBaseBean> klass, String... rels) throws Exception {
-		Set<Relationship> results = eiHandler.getRelatedEntities(klass);
+		Set<Relationship> results = EntityInfoHandler.getRelatedEntities(klass);
 		Set<String> rStrings = new HashSet<String>();
 		for (Relationship rel : results) {
 			rStrings.add(rel.toString());
@@ -292,7 +290,7 @@ public class TestEntityInfo {
 		for (String rel : rels) {
 			assertTrue(klass.getSimpleName() + " value " + rel, rStrings.contains(rel));
 		}
-		Set<Entry<String, Relationship>> map = eiHandler.getRelationshipsByName(klass).entrySet();
+		Set<Entry<String, Relationship>> map = EntityInfoHandler.getRelationshipsByName(klass).entrySet();
 		assertEquals(rels.length, map.size());
 		for (Entry<String, Relationship> e : map) {
 			Relationship rel = e.getValue();
@@ -320,7 +318,7 @@ public class TestEntityInfo {
 	}
 
 	private void testOne(Class<? extends EntityBaseBean> klass, String... rels) throws Exception {
-		Set<Relationship> results = eiHandler.getOnes(klass);
+		Set<Relationship> results = EntityInfoHandler.getOnes(klass);
 		Set<String> rStrings = new HashSet<String>();
 		for (Relationship rel : results) {
 			rStrings.add(rel.getDestinationBean().getSimpleName());
@@ -345,7 +343,7 @@ public class TestEntityInfo {
 	}
 
 	private void testNNF(Class<? extends EntityBaseBean> klass, String... nnfs) throws Exception {
-		List<Field> results = eiHandler.getNotNullableFields(klass);
+		List<Field> results = EntityInfoHandler.getNotNullableFields(klass);
 		Set<String> rStrings = new HashSet<String>();
 		for (Field field : results) {
 			rStrings.add(field.getName());
@@ -371,7 +369,7 @@ public class TestEntityInfo {
 	}
 
 	private void testSF(Class<? extends EntityBaseBean> klass, String... sfs) throws Exception {
-		Map<Field, Integer> results = eiHandler.getStringFields(klass);
+		Map<Field, Integer> results = EntityInfoHandler.getStringFields(klass);
 		Set<String> rStrings = new HashSet<String>();
 		for (Entry<Field, Integer> entry : results.entrySet()) {
 			rStrings.add(entry.getKey().getName() + " " + entry.getValue());
@@ -430,7 +428,7 @@ public class TestEntityInfo {
 	}
 
 	private void testRelInkey(Class<? extends EntityBaseBean> klass, String... fieldNames) throws Exception {
-		Set<Field> results = eiHandler.getRelInKey(klass);
+		Set<Field> results = EntityInfoHandler.getRelInKey(klass);
 		Set<String> rStrings = new HashSet<String>();
 		for (Field field : results) {
 			rStrings.add(field.getName());
@@ -443,7 +441,7 @@ public class TestEntityInfo {
 	}
 
 	private void testGetters(Class<? extends EntityBaseBean> klass, int count) throws Exception {
-		Map<Field, Method> results = eiHandler.getGetters(klass);
+		Map<Field, Method> results = EntityInfoHandler.getGetters(klass);
 		assertEquals(klass.getSimpleName() + " count", count, results.size());
 		for (Entry<Field, Method> entry : results.entrySet()) {
 			String cap = entry.getKey().getName();
@@ -454,7 +452,7 @@ public class TestEntityInfo {
 	}
 
 	private void testSettersForUpdate(Class<? extends EntityBaseBean> klass, int count) throws Exception {
-		Map<Field, Method> results = eiHandler.getSettersForUpdate(klass);
+		Map<Field, Method> results = EntityInfoHandler.getSettersForUpdate(klass);
 
 		assertEquals(klass.getSimpleName() + " count", count, results.size());
 		for (Entry<Field, Method> entry : results.entrySet()) {
@@ -466,7 +464,7 @@ public class TestEntityInfo {
 	}
 
 	private void testSetters(Class<? extends EntityBaseBean> klass, int count) throws Exception {
-		Map<Field, Method> results = eiHandler.getSetters(klass);
+		Map<Field, Method> results = EntityInfoHandler.getSetters(klass);
 		assertEquals(klass.getSimpleName() + " count", count, results.size());
 		for (Entry<Field, Method> entry : results.entrySet()) {
 			String cap = entry.getKey().getName();

--- a/src/test/java/org/icatproject/integration/TestWS.java
+++ b/src/test/java/org/icatproject/integration/TestWS.java
@@ -239,7 +239,7 @@ public class TestWS {
 			fail("Should have thrown exception");
 		} catch (IcatException_Exception e) {
 			assertEquals(IcatExceptionType.BAD_PARAMETER, e.getFaultInfo().getType());
-			assertEquals("Applicatio is not an EntityBaseBean", e.getMessage());
+			assertEquals("Applicatio is not an ICAT entity", e.getMessage());
 		}
 
 		ps = new PublicStep();
@@ -1138,7 +1138,7 @@ public class TestWS {
 			fail("No throw");
 		} catch (IcatException_Exception e) {
 			assertEquals(IcatExceptionType.BAD_PARAMETER, e.getFaultInfo().getType());
-			assertEquals("Investigator is not an EntityBaseBean", e.getMessage());
+			assertEquals("Investigator is not an ICAT entity", e.getMessage());
 		}
 		try {
 			session.get("Dataset INCLUDE Investigation, Facility, Instrument", dsId);
@@ -1508,7 +1508,7 @@ public class TestWS {
 			fail("No throw");
 		} catch (IcatException_Exception e) {
 			assertEquals(IcatExceptionType.BAD_PARAMETER, e.getFaultInfo().getType());
-			assertEquals("Investigator is not an EntityBaseBean", e.getMessage());
+			assertEquals("Investigator is not an ICAT entity", e.getMessage());
 		}
 		try {
 			session.get("Dataset INCLUDE Investigation, Facility, Instrument", dsId);

--- a/src/test/java/org/icatproject/integration/TestWS.java
+++ b/src/test/java/org/icatproject/integration/TestWS.java
@@ -1052,7 +1052,7 @@ public class TestWS {
 		session.addUserGroupMember("root", "root");
 		session.addUserGroupMember("root", "useroffice");
 
-		for (String t : EntityInfoHandler.getAlphabeticEntityNames()) {
+		for (String t : EntityInfoHandler.getEntityNamesList()) {
 			session.addRule("root", "SELECT x FROM " + t + " x", "CRUD");
 			session.addRule("notroot", "SELECT x FROM " + t + " x", "CRUD");
 		}


### PR DESCRIPTION
In order to remove synchronized blocks, the PrivateEntityInfo instances are created during class static initialization and stored in immutable objects, making the class fully thread-safe.

Since everything is available in static variables, there is no need to instantiate the class, so all the methods are made static.