### PR TITLE
Fix CI Build workflow

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -38,7 +38,6 @@ jobs:
         with:
           repository: icatproject-contrib/icat-ansible
           path: icat-ansible
-          ref: icat-6.1
       - name: Install Ansible
         run: pip install -r icat-ansible/requirements.txt
 


### PR DESCRIPTION
The CI Build workflow fails in step "Checkout icat-ansible" because it cannot checkout the `icat-6.1` branch of icat-ansible: this branch has been merged into master in icatproject-contrib/icat-ansible#114.
