### PR TITLE
Disable db triggers in the CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -51,6 +51,9 @@ jobs:
       - name: Replace default payara user with Actions user
         run: |
           sed -i -e "s/^payara_user: \"glassfish\"/payara_user: \"runner\"/" icat-ansible/group_vars/all/vars.yml
+      - name: Disable DB triggers
+        run: |
+          echo 'icat_server_install_db_triggers: false' >> icat-ansible/group_vars/all/vars.yml
 
       # Force hostname to localhost - bug fix for previous ICAT Ansible issues on Actions
       - name: Change hostname to localhost


### PR DESCRIPTION
Intended to fix failures like:
```
importMetaDataAll(org.icatproject.integration.TestRS)  Time elapsed: 0.798 sec  <<< ERROR!
org.icatproject.icat.client.IcatException: Duplicate check fails for field fileCount of Investigation at line 29
	at org.icatproject.icat.client.ICAT.checkStatus(ICAT.java:114)
	at org.icatproject.icat.client.ICAT.expectNothing(ICAT.java:170)
	at org.icatproject.icat.client.ICAT.importMetaData(ICAT.java:371)
	at org.icatproject.icat.client.Session.importMetaData(Session.java:291)
	at org.icatproject.integration.TestRS.importMetaData(TestRS.java:2468)
	at org.icatproject.integration.TestRS.importMetaDataAll(TestRS.java:2297)

importMetaDataUser(org.icatproject.integration.TestRS)  Time elapsed: 0.686 sec  <<< ERROR!
org.icatproject.icat.client.IcatException: Duplicate check fails for field fileCount of Investigation at line 29
	at org.icatproject.icat.client.ICAT.checkStatus(ICAT.java:114)
	at org.icatproject.icat.client.ICAT.expectNothing(ICAT.java:170)
	at org.icatproject.icat.client.ICAT.importMetaData(ICAT.java:371)
	at org.icatproject.icat.client.Session.importMetaData(Session.java:291)
	at org.icatproject.integration.TestRS.importMetaData(TestRS.java:2468)
	at org.icatproject.integration.TestRS.importMetaDataUser(TestRS.java:2292)
```
observed on #350 and #348 . The default behaviour of installing the triggers was added in 2023, so not sure why it hasn't been a problem until now?