### PR TITLE
Make publicSearchFields, getPublicSearchFields non-static

### DIFF
--- a/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
+++ b/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
@@ -1489,7 +1489,7 @@ public class EntityBeanManager {
 		List<ScoredEntityBaseBean> results = new ArrayList<>();
 		List<FacetDimension> dimensions = new ArrayList<>();
 		if (searchActive) {
-			List<String> fields = SearchManager.getPublicSearchFields(gateKeeper, klass.getSimpleName());
+			List<String> fields = searchManager.getPublicSearchFields(gateKeeper, klass.getSimpleName());
 			lastSearchAfter = searchDocuments(userName, jo, searchAfter, maxCount, minCount, sort, manager, klass,
 					startMillis, results, fields);
 

--- a/src/main/java/org/icatproject/core/manager/search/SearchManager.java
+++ b/src/main/java/org/icatproject/core/manager/search/SearchManager.java
@@ -419,7 +419,7 @@ public class SearchManager {
 
 	private List<URL> urls;
 
-	private static final Map<String, List<String>> publicSearchFields = new HashMap<>();
+	private final Map<String, List<String>> publicSearchFields = new HashMap<>();
 
 	/**
 	 * Gets (and if necessary, builds) the fields which should be returned as part
@@ -431,7 +431,7 @@ public class SearchManager {
 	 *         entity is authorised.
 	 * @throws IcatException
 	 */
-	public static List<String> getPublicSearchFields(GateKeeper gateKeeper, String simpleName) throws IcatException {
+	public List<String> getPublicSearchFields(GateKeeper gateKeeper, String simpleName) throws IcatException {
 		if (gateKeeper.getPublicSearchFieldsStale() || publicSearchFields.size() == 0) {
 			logger.info("Building public search fields from public tables and steps");
 			publicSearchFields.put("Datafile", buildPublicSearchFields(gateKeeper, Datafile.getDocumentFields()));


### PR DESCRIPTION
While deploying, noticed that sometimes the list of "public" fields to request are included in the Documents returned from Lucene is incorrect, with some expected fields missing. From looking at the logs, since DataGateway with the default indexes sends three requests for `Investigation`, `Dataset` and `Datafile` at the same time, these requests were resulting in the `publicSearchFields` being modified concurrently:
```
2025-04-11 10:27:02,749 DEBUG [http-thread-pool::http-listener-2(5)] EntityBeanManager - user: simple/root is associated with: 64fbec46-c6c5-4cbb-bc68-eab7cfd8301d
2025-04-11 10:27:02,749 INFO [http-thread-pool::http-listener-2(5)] SearchManager - Building public search fields from public tables and steps
2025-04-11 10:27:02,751 DEBUG [http-thread-pool::http-listener-2(5)] GateKeeper - There are 0 publicTables: []
2025-04-11 10:27:02,754 DEBUG [http-thread-pool::http-listener-2(4)] EntityBeanManager - user: simple/root is associated with: 64fbec46-c6c5-4cbb-bc68-eab7cfd8301d
2025-04-11 10:27:02,755 DEBUG [http-thread-pool::http-listener-2(5)] GateKeeper - There are 0 publicSteps: {}
2025-04-11 10:27:02,755 INFO [http-thread-pool::http-listener-2(4)] SearchManager - Building public search fields from public tables and steps
2025-04-11 10:27:02,756 DEBUG [http-thread-pool::http-listener-2(1)] EntityBeanManager - user: simple/root is associated with: 64fbec46-c6c5-4cbb-bc68-eab7cfd8301d
2025-04-11 10:27:02,757 INFO [http-thread-pool::http-listener-2(1)] SearchManager - Building public search fields from public tables and steps
2025-04-11 10:27:02,758 TRACE [http-thread-pool::http-listener-2(4)] SearchManager - Built Datafile fields
2025-04-11 10:27:02,759 TRACE [http-thread-pool::http-listener-2(4)] SearchManager - Built Dataset fields
2025-04-11 10:27:02,760 TRACE [http-thread-pool::http-listener-2(4)] SearchManager - Built Investigation fields
2025-04-11 10:27:02,760 DEBUG [http-thread-pool::http-listener-2(4)] SearchManager - Investigation has public fields [date, endDate, title, fileCount, visitId, id, summary, type.id, facility.id, fileSize, name, startDate, doi]
2025-04-11 10:27:02,760 TRACE [http-thread-pool::http-listener-2(4)] SearchApi - Making call https://host-172-16-113-131.nubes.stfc.ac.uk:8181/icat.lucene/investigation?maxResults=1000 with body {"query":{"target":"Investigation"},"fields":["date","endDate","title","fileCount","visitId","id","summary","type.id","facility.id","fileSize","name","startDate","doi"]}
2025-04-11 10:27:02,761 TRACE [http-thread-pool::http-listener-2(5)] SearchManager - Built Datafile fields
2025-04-11 10:27:02,762 TRACE [http-thread-pool::http-listener-2(5)] SearchManager - Built Dataset fields
2025-04-11 10:27:02,764 TRACE [http-thread-pool::http-listener-2(1)] SearchManager - Built Datafile fields
2025-04-11 10:27:02,764 TRACE [http-thread-pool::http-listener-2(5)] SearchManager - Built Investigation fields
2025-04-11 10:27:02,764 DEBUG [http-thread-pool::http-listener-2(5)] SearchManager - Datafile has public fields [date, description, datafileFormat.id, fileCount, dataset.id, fileSize, name, location, id, doi]
2025-04-11 10:27:02,765 TRACE [http-thread-pool::http-listener-2(1)] SearchManager - Built Dataset fields
2025-04-11 10:27:02,766 TRACE [http-thread-pool::http-listener-2(1)] SearchManager - Built Investigation fields
2025-04-11 10:27:02,767 DEBUG [http-thread-pool::http-listener-2(1)] SearchManager - Dataset has public fields [date, endDate, description, sample.id, type.id, fileCount, fileSize, name, investigation.id, id, startDate, doi]
2025-04-11 10:27:02,770 DEBUG [http-thread-pool::http-listener-2(4)] EntityBeanManager - Got 0 results from search engine
2025-04-11 10:27:02,770 DEBUG [http-thread-pool::http-listener-2(4)] EntityBeanManager - Returning 0 results
2025-04-11 10:27:02,771 TRACE [http-thread-pool::http-listener-2(5)] SearchApi - Making call https://host-172-16-113-131.nubes.stfc.ac.uk:8181/icat.lucene/datafile?maxResults=1000 with body {"query":{"target":"Datafile"},"fields":["date","description","datafileFormat.id","fileCount","dataset.id","fileSize","name","location","id","doi"]}
2025-04-11 10:27:02,779 DEBUG [http-thread-pool::http-listener-2(5)] EntityBeanManager - Got 0 results from search engine
2025-04-11 10:27:02,780 DEBUG [http-thread-pool::http-listener-2(5)] EntityBeanManager - Returning 0 results
2025-04-11 10:27:02,780 TRACE [http-thread-pool::http-listener-2(1)] SearchApi - Making call https://host-172-16-113-131.nubes.stfc.ac.uk:8181/icat.lucene/dataset?maxResults=1000 with body {"query":{"target":"Dataset"},"fields":["date","endDate","description","sample.id","type.id","fileCount","fileSize","name","investigation.id","id","startDate","doi"]}
2025-04-11 10:27:02,786 DEBUG [http-thread-pool::http-listener-2(1)] EntityBeanManager - Got 0 results from search engine
2025-04-11 10:27:02,786 DEBUG [http-thread-pool::http-listener-2(1)] EntityBeanManager - Returning 0 results
```

I'm not 100% sure what mechanism would then lead to some entries being missing from the `List<String>`, but it was intended that this function would be write locked and it is not possible for two calls to modify the map at the same time.

To resolve this, have made the function/map non-static. There may be a better way to handle this/get the intended behaviour, so suggestions welcome, but behaviour is now:
```
2025-04-11 10:38:36,308 DEBUG [http-thread-pool::http-listener-2(2)] EntityBeanManager - user: simple/root is associated with: 64fbec46-c6c5-4cbb-bc68-eab7cfd8301d
2025-04-11 10:38:36,308 INFO [http-thread-pool::http-listener-2(2)] SearchManager - Building public search fields from public tables and steps
2025-04-11 10:38:36,313 DEBUG [http-thread-pool::http-listener-2(2)] GateKeeper - There are 0 publicTables: []
2025-04-11 10:38:36,313 DEBUG [http-thread-pool::http-listener-2(2)] GateKeeper - There are 0 publicSteps: {}
2025-04-11 10:38:36,315 TRACE [http-thread-pool::http-listener-2(2)] SearchManager - Built Datafile fields
2025-04-11 10:38:36,317 TRACE [http-thread-pool::http-listener-2(2)] SearchManager - Built Dataset fields
2025-04-11 10:38:36,319 TRACE [http-thread-pool::http-listener-2(2)] SearchManager - Built Investigation fields
2025-04-11 10:38:36,319 DEBUG [http-thread-pool::http-listener-2(2)] SearchManager - Dataset has public fields [date, endDate, description, sample.id, type.id, fileCount, fileSize, name, investigation.id, id, startDate, doi]
2025-04-11 10:38:36,320 DEBUG [http-thread-pool::http-listener-2(3)] EntityBeanManager - user: simple/root is associated with: 64fbec46-c6c5-4cbb-bc68-eab7cfd8301d
2025-04-11 10:38:36,320 DEBUG [http-thread-pool::http-listener-2(4)] EntityBeanManager - user: simple/root is associated with: 64fbec46-c6c5-4cbb-bc68-eab7cfd8301d
2025-04-11 10:38:36,321 TRACE [http-thread-pool::http-listener-2(2)] SearchApi - Making call https://host-172-16-113-131.nubes.stfc.ac.uk:8181/icat.lucene/dataset?maxResults=1000 with body {"query":{"target":"Dataset"},"fields":["date","endDate","description","sample.id","type.id","fileCount","fileSize","name","investigation.id","id","startDate","doi"]}
2025-04-11 10:38:36,328 DEBUG [http-thread-pool::http-listener-2(2)] EntityBeanManager - Got 0 results from search engine
2025-04-11 10:38:36,328 DEBUG [http-thread-pool::http-listener-2(2)] EntityBeanManager - Returning 0 results
2025-04-11 10:38:36,329 DEBUG [http-thread-pool::http-listener-2(3)] SearchManager - Datafile has public fields [date, description, datafileFormat.id, fileCount, dataset.id, fileSize, name, location, id, doi]
2025-04-11 10:38:36,329 DEBUG [http-thread-pool::http-listener-2(4)] SearchManager - Investigation has public fields [date, endDate, title, fileCount, visitId, id, summary, type.id, facility.id, fileSize, name, startDate, doi]
2025-04-11 10:38:36,330 TRACE [http-thread-pool::http-listener-2(3)] SearchApi - Making call https://host-172-16-113-131.nubes.stfc.ac.uk:8181/icat.lucene/datafile?maxResults=1000 with body {"query":{"target":"Datafile"},"fields":["date","description","datafileFormat.id","fileCount","dataset.id","fileSize","name","location","id","doi"]}
2025-04-11 10:38:36,339 DEBUG [http-thread-pool::http-listener-2(3)] EntityBeanManager - Got 0 results from search engine
2025-04-11 10:38:36,339 DEBUG [http-thread-pool::http-listener-2(3)] EntityBeanManager - Returning 0 results
2025-04-11 10:38:36,340 TRACE [http-thread-pool::http-listener-2(4)] SearchApi - Making call https://host-172-16-113-131.nubes.stfc.ac.uk:8181/icat.lucene/investigation?maxResults=1000 with body {"query":{"target":"Investigation"},"fields":["date","endDate","title","fileCount","visitId","id","summary","type.id","facility.id","fileSize","name","startDate","doi"]}
2025-04-11 10:38:36,348 DEBUG [http-thread-pool::http-listener-2(4)] EntityBeanManager - Got 0 results from search engine
2025-04-11 10:38:36,348 DEBUG [http-thread-pool::http-listener-2(4)] EntityBeanManager - Returning 0 results
```