### PR TITLE
Fix workflow status badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # icat.server
 
-[![Build Status](https://github.com/icatproject/icat.server/workflows/CI%20Build/badge.svg?branch=master)](https://github.com/icatproject/icat.server/actions?query=workflow%3A%22CI+Build%22)
+[![Build Status](https://github.com/icatproject/icat.server/actions/workflows/ci-build.yml/badge.svg?branch=master)](https://github.com/icatproject/icat.server/actions/workflows/ci-build.yml)
 
 General installation instructions are at https://icatproject.org/installation/component
 


### PR DESCRIPTION
This is a minor aesthetic fix: the `CI Build` status badge in the README has stopped working, it always displays a gray "no status".  The reason is that GitHub changed the URLs to use for those badges a while ago.  I didn't found the documentation describing the change again, but see the [current documentation](https://docs.github.com/en/actions/monitoring-and-troubleshooting-workflows/monitoring-workflows/adding-a-workflow-status-badge).