### PR TITLE
Improve queue file handling when indexing

### DIFF
--- a/src/main/java/org/icatproject/core/manager/PropertyHandler.java
+++ b/src/main/java/org/icatproject/core/manager/PropertyHandler.java
@@ -318,6 +318,7 @@ public class PropertyHandler {
 	private int searchIndexBatchSize;
 	private int searchIndexBatchesPerTimer;
 	private int searchBacklogLinesPerTimer;
+	private long searchQueueFileMaxSize;
 
 	@PostConstruct
 	private void init() {
@@ -625,6 +626,14 @@ public class PropertyHandler {
 			} else {
 				searchBacklogLinesPerTimer = SearchManager.DEFAULT_BACKLOG_LINES_PER_TIMER;
 			}
+
+			key = "search.queueFileMaxSize";
+			if (props.has(key)) {
+				searchQueueFileMaxSize = props.getPositiveLong(key);
+				formattedProps.add("search.queueFileMaxSize " + searchQueueFileMaxSize);
+			} else {
+				searchQueueFileMaxSize = SearchManager.DEFAULT_QUEUE_FILE_MAX_SIZE;
+			}
 		} catch (CheckedPropertyException e) {
 			abend(e.getMessage());
 		}
@@ -730,5 +739,9 @@ public class PropertyHandler {
 
 	public int getSearchBacklogLinesPerTimer() {
 		return searchBacklogLinesPerTimer;
+	}
+
+	public long getSearchQueueFileMaxSize() {
+		return searchQueueFileMaxSize;
 	}
 }

--- a/src/main/java/org/icatproject/core/manager/PropertyHandler.java
+++ b/src/main/java/org/icatproject/core/manager/PropertyHandler.java
@@ -51,6 +51,7 @@ import org.icatproject.authentication.Authentication;
 import org.icatproject.authentication.Authenticator;
 import org.icatproject.core.IcatException;
 import org.icatproject.core.IcatException.IcatExceptionType;
+import org.icatproject.core.manager.search.SearchManager;
 import org.icatproject.utils.CheckedProperties;
 import org.icatproject.utils.CheckedProperties.CheckedPropertyException;
 import org.icatproject.utils.ContainerGetter;
@@ -314,6 +315,9 @@ public class PropertyHandler {
 	private String unitAliasOptions;
 	private Map<String, String> cluster = new HashMap<>();
 	private long searchEnqueuedRequestIntervalMillis;
+	private int searchIndexBatchSize;
+	private int searchIndexBatchesPerTimer;
+	private int searchBacklogLinesPerTimer;
 
 	@PostConstruct
 	private void init() {
@@ -597,6 +601,30 @@ public class PropertyHandler {
 			if (containerType == ContainerType.UNKNOWN) {
 				abend("Container type " + containerType + " is not recognised");
 			}
+
+			key = "search.indexBatchSize";
+			if (props.has(key)) {
+				searchIndexBatchSize = props.getPositiveInt(key);
+				formattedProps.add("search.indexBatchSize " + searchIndexBatchSize);
+			} else {
+				searchIndexBatchSize = SearchManager.DEFAULT_INDEX_BATCH_SIZE;
+			}
+
+			key = "search.indexBatchesPerTimer";
+			if (props.has(key)) {
+				searchIndexBatchesPerTimer = props.getPositiveInt(key);
+				formattedProps.add("search.indexBatchesPerTimer " + searchIndexBatchesPerTimer);
+			} else {
+				searchIndexBatchesPerTimer = SearchManager.DEFAULT_INDEX_BATCHES_PER_TIMER;
+			}
+
+			key = "search.backlogLinesPerTimer";
+			if (props.has(key)) {
+				searchBacklogLinesPerTimer = props.getPositiveInt(key);
+				formattedProps.add("search.backlogLinesPerTimer " + searchBacklogLinesPerTimer);
+			} else {
+				searchBacklogLinesPerTimer = SearchManager.DEFAULT_BACKLOG_LINES_PER_TIMER;
+			}
 		} catch (CheckedPropertyException e) {
 			abend(e.getMessage());
 		}
@@ -692,4 +720,15 @@ public class PropertyHandler {
 		return unitAliasOptions;
 	}
 
+	public int getSearchIndexBatchSize() {
+		return searchIndexBatchSize;
+	}
+
+	public int getSearchIndexBatchesPerTimer() {
+		return searchIndexBatchesPerTimer;
+	}
+
+	public int getSearchBacklogLinesPerTimer() {
+		return searchBacklogLinesPerTimer;
+	}
 }

--- a/src/main/java/org/icatproject/core/manager/search/SearchManager.java
+++ b/src/main/java/org/icatproject/core/manager/search/SearchManager.java
@@ -734,20 +734,13 @@ public class SearchManager {
 	private void exit() {
 		logger.info("Closing down SearchManager");
 		if (active) {
-			try {
-				populateExecutor.shutdown();
-				getBeanDocExecutor.shutdown();
+			populateExecutor.shutdown();
+			getBeanDocExecutor.shutdown();
 
-				// Presumably, this is to wait for indexing to complete before shutting down?
-				// TODO: Need a way to gracefully stop indexing quickly and confirm that it is complete.
-				pushPendingCalls();
+			// Stops new TimerTask executions. If a TimerTask is currently running, it will continue until completed.
+			timer.cancel();
 
-				timer.cancel();
-				timer = null;
-				logger.info("Closed down SearchManager");
-			} catch (Exception e) {
-				logger.error(fatal, "Problem closing down SearchManager", e);
-			}
+			logger.info("Closed down SearchManager");
 		}
 	}
 

--- a/src/main/java/org/icatproject/core/manager/search/SearchManager.java
+++ b/src/main/java/org/icatproject/core/manager/search/SearchManager.java
@@ -43,6 +43,7 @@ import jakarta.json.JsonValue;
 import jakarta.json.JsonValue.ValueType;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityManagerFactory;
+import jakarta.persistence.NoResultException;
 import jakarta.persistence.PersistenceUnit;
 
 import org.icatproject.core.IcatException;
@@ -307,8 +308,11 @@ public class SearchManager {
 							try {
 								EntityBaseBean entity = entityManager.createQuery(query, klass).getSingleResult();
 								updateDocument(entityManager, entity);
-							} catch (Exception e) { //TODO: refine this
-								logger.error("{} with id {} not found, continue", entityName, line);
+							} catch (NoResultException e) {
+								logger.debug("{} with id {} not found, continue", entityName, line);
+							} catch (IcatException e) {
+								logger.error("Failed to index aggregation", e);
+								return;
 							}
 						}
 					}

--- a/src/main/java/org/icatproject/core/manager/search/SearchManager.java
+++ b/src/main/java/org/icatproject/core/manager/search/SearchManager.java
@@ -84,7 +84,7 @@ public class SearchManager {
 					}
 
 					if (path == null) {
-						logger.debug("No queue file available to process");
+						logger.trace("No queue file available to process");
 						return;
 					}
 
@@ -200,7 +200,7 @@ public class SearchManager {
 					}
 
 					if (path == null) {
-						logger.debug("No backlog file available to process");
+						logger.trace("No backlog file available to process");
 						return;
 					}
 
@@ -290,7 +290,7 @@ public class SearchManager {
 				}
 
 				if (path == null) {
-					logger.debug("No aggregation file available to process");
+					logger.trace("No aggregation file available to process");
 					return;
 				}
 

--- a/src/main/java/org/icatproject/core/manager/search/SearchManager.java
+++ b/src/main/java/org/icatproject/core/manager/search/SearchManager.java
@@ -136,6 +136,7 @@ public class SearchManager {
 						try {
 							backlog.synchronizedWrite(sb.toString());
 							Files.move(dotnewPath, path,StandardCopyOption.REPLACE_EXISTING);
+							return;
 						} catch (IcatException e2) {
 							// Already logged
 							return;

--- a/src/main/java/org/icatproject/core/manager/search/SearchManager.java
+++ b/src/main/java/org/icatproject/core/manager/search/SearchManager.java
@@ -68,12 +68,13 @@ public class SearchManager {
 
 	// TODO: Make this configurable
 	private static int INDEX_BATCH_SIZE = 500;
+	private static int INDEX_BATCHES_PER_TIMER = 10;
 
 	public class EnqueuedSearchRequestHandler extends TimerTask {
 
 		@Override
 		public void run() {
-			while (true) {
+			for (int i = 0; i < INDEX_BATCHES_PER_TIMER; i++) {
 				synchronized (queue.getReadLock()) {
 					Path path;
 					try {
@@ -95,7 +96,7 @@ public class SearchManager {
 					StringBuilder sb = new StringBuilder("[");
 
 					try (BufferedReader reader = Files.newBufferedReader(path)) {
-						for (int i = 0; i < INDEX_BATCH_SIZE; i++) {
+						for (int j = 0; j < INDEX_BATCH_SIZE; j++) {
 							String line = reader.readLine();
 							if (line == null) {
 								break;
@@ -190,7 +191,7 @@ public class SearchManager {
 
 		@Override
 		public void run() {
-			while (true) {
+			for (int i = 0; i < INDEX_BATCHES_PER_TIMER; i++) {
 				synchronized (backlog.getReadLock()) {
 					Path path;
 					try {

--- a/src/main/java/org/icatproject/core/manager/search/queue/RotatingFileQueue.java
+++ b/src/main/java/org/icatproject/core/manager/search/queue/RotatingFileQueue.java
@@ -69,7 +69,7 @@ public class RotatingFileQueue {
 	}
 
 	private void rotate() throws IcatException {
-		logger.debug("Rotating queue file: {}", writePath);
+		logger.trace("Rotating queue file: {}", writePath);
 
 		synchronized (readLock) {
 			// get current list of numbered files
@@ -132,7 +132,7 @@ public class RotatingFileQueue {
 				return entry.getValue();
 			}
 
-			logger.debug("Rotating queue file due to exhaustion: {}", writePath);
+			logger.trace("Rotating queue file due to exhaustion: {}", writePath);
 			rotate();
 
 			Map.Entry<Integer, Path> entry = getNumberedFiles().lastEntry();

--- a/src/main/java/org/icatproject/core/manager/search/queue/RotatingFileQueue.java
+++ b/src/main/java/org/icatproject/core/manager/search/queue/RotatingFileQueue.java
@@ -1,6 +1,7 @@
 package org.icatproject.core.manager.search.queue;
 
 import java.io.BufferedWriter;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -53,9 +54,11 @@ public class RotatingFileQueue {
 		long size = 0L;
 		try {
 			size = Files.size(writePath);
+		} catch (FileNotFoundException e) {
+			// Ignore
 		} catch (IOException e) {
-			logger.debug("Error checking queue file size: {}", writePath, e);
-			// File may not exist, ignore
+			logger.warn("Error checking queue file size: {}", writePath, e);
+			// Ignore
 		}
 		if (size > MAX_SIZE) {
 			logger.debug("Rotating queue file due to size {}: {}", size, writePath);

--- a/src/main/java/org/icatproject/core/manager/search/queue/RotatingFileQueue.java
+++ b/src/main/java/org/icatproject/core/manager/search/queue/RotatingFileQueue.java
@@ -1,0 +1,188 @@
+package org.icatproject.core.manager.search.queue;
+
+import java.io.BufferedWriter;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import java.util.stream.Collectors;
+
+import org.icatproject.core.IcatException;
+import org.icatproject.core.IcatException.IcatExceptionType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class RotatingFileQueue {
+
+	private static final long MAX_SIZE = 10_000_000L;
+	private static final Logger logger = LoggerFactory.getLogger(RotatingFileQueue.class);
+
+	private final Path directory;
+	private final String filename;
+	private final Path writePath;
+
+	private final Object writeLock = new Object();
+	private final Object readLock = new Object();
+
+	public RotatingFileQueue(Path directory, String filename) {
+		this.directory = directory;
+		this.filename = filename;
+		this.writePath = directory.resolve(filename);
+	}
+
+	public void synchronizedWrite(String line) throws IcatException {
+
+		logger.trace("Writing {} to {}", line, writePath);
+
+		synchronized (writeLock) {
+			try (BufferedWriter writer = Files.newBufferedWriter(writePath, StandardOpenOption.APPEND, StandardOpenOption.CREATE)) {
+				writer.write(line);
+				writer.newLine();
+			} catch (IOException e) {
+				logger.error("Error writing to queue file: {}", writePath, e);
+				throw new IcatException(IcatExceptionType.INTERNAL, "Error writing to queue file");
+			}
+		}
+	}
+
+	private boolean checkSize() {
+		long size = 0L;
+		try {
+			size = Files.size(writePath);
+		} catch (IOException e) {
+			logger.debug("Error checking queue file size: {}", writePath, e);
+			// File may not exist, ignore
+		}
+		if (size > MAX_SIZE) {
+			logger.debug("Rotating queue file due to size {}: {}", size, writePath);
+			return true;
+		}
+
+		return false;
+	}
+
+	private void rotate() throws IcatException {
+		logger.debug("Rotating queue file: {}", writePath);
+
+		synchronized (readLock) {
+			// get current list of numbered files
+			NavigableMap<Integer, Path> filemap = getNumberedFiles();
+
+			while (!filemap.isEmpty()) {
+				Map.Entry<Integer, Path> entry = filemap.pollLastEntry();
+
+				Integer existingNumber = entry.getKey();
+				Path existingPath = entry.getValue();
+
+				Integer newNumber = existingNumber + 1;
+				String newFilename = filename + "." + newNumber.toString();
+				Path newPath = directory.resolve(newFilename);
+
+				checkedMove(existingPath, newPath);
+			}
+
+			synchronized (writeLock) {
+				Path existingPath = writePath;
+				Path newPath = directory.resolve(filename + ".0");
+
+				if (Files.exists(existingPath)) {
+					checkedMove(existingPath, newPath);
+				}
+			}
+		}
+	}
+
+	public Path getReadPath() throws IcatException {
+		synchronized (readLock) {
+			if (checkSize()) {
+				rotate();
+			}
+
+			NavigableMap<Integer, Path> filemap = getNumberedFiles();
+
+			while (!filemap.isEmpty()) {
+				Map.Entry<Integer, Path> entry = filemap.pollLastEntry();
+
+				Long size = null;
+				try {
+					size = Files.size(entry.getValue());
+				} catch (IOException e) {
+					logger.error("Error checking queue file size: {}", entry.getValue(), e);
+					throw new IcatException(IcatExceptionType.INTERNAL, "Error checking queue file size");
+				}
+
+				if (size == 0L) {
+					logger.debug("Deleting empty queue file: {}", entry.getValue());
+					try {
+						Files.delete(entry.getValue());
+					} catch (IOException e) {
+						logger.error("Error deleting queue file: {}", entry.getValue(), e);
+						throw new IcatException(IcatExceptionType.INTERNAL, "Error deleting queue file");
+					}
+					continue;
+				}
+
+				return entry.getValue();
+			}
+
+			logger.debug("Rotating queue file due to exhaustion: {}", writePath);
+			rotate();
+
+			Map.Entry<Integer, Path> entry = getNumberedFiles().lastEntry();
+			if (entry != null) {
+				return entry.getValue();
+			}
+		}
+
+		return null;
+	}
+
+	private void checkedMove(Path existingPath, Path newPath) throws IcatException {
+		logger.debug("Moving {} -> {}", existingPath, newPath);
+
+		try {
+			Files.move(existingPath, newPath);
+		} catch (IOException e) {
+			logger.error("Error rotating queue file: {} -> {}", existingPath, newPath, e);
+			throw new IcatException(IcatExceptionType.INTERNAL, "Error rotating queue file");
+		}
+	}
+
+	private NavigableMap<Integer, Path> getNumberedFiles() throws IcatException {
+		synchronized (readLock) {
+			List<Path> files;
+			try {
+				files = Files.list(directory).collect(Collectors.toList());
+			} catch (IOException e) {
+				logger.error("Error reading directory: {}", directory, e);
+				throw new IcatException(IcatExceptionType.INTERNAL, "Error reading queue file directory");
+			}
+
+			NavigableMap<Integer, Path> filemap = new TreeMap<>();
+
+			for (Path file : files) {
+				if (file.getFileName().toString().startsWith(filename + ".")) {
+					String end = file.getFileName().toString().substring(filename.length() + 1);
+
+					try {
+						Integer n = Integer.valueOf(end);
+						filemap.put(n, file);
+					} catch (NumberFormatException e) {
+						logger.warn("Ignoring file: {}", directory);
+						// Ignore
+					}
+				}
+			}
+
+			return filemap;
+		}
+	}
+
+	public Object getReadLock() {
+		return readLock;
+	}
+}

--- a/src/main/java/org/icatproject/core/manager/search/queue/RotatingFileQueue.java
+++ b/src/main/java/org/icatproject/core/manager/search/queue/RotatingFileQueue.java
@@ -1,7 +1,7 @@
 package org.icatproject.core.manager.search.queue;
 
 import java.io.BufferedWriter;
-import java.io.FileNotFoundException;
+import java.nio.file.NoSuchFileException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -54,7 +54,7 @@ public class RotatingFileQueue {
 		long size = 0L;
 		try {
 			size = Files.size(writePath);
-		} catch (FileNotFoundException e) {
+		} catch (NoSuchFileException e) {
 			// Ignore
 		} catch (IOException e) {
 			logger.warn("Error checking queue file size: {}", writePath, e);

--- a/src/main/java/org/icatproject/core/manager/search/queue/RotatingFileQueue.java
+++ b/src/main/java/org/icatproject/core/manager/search/queue/RotatingFileQueue.java
@@ -175,7 +175,7 @@ public class RotatingFileQueue {
 						Integer n = Integer.valueOf(end);
 						filemap.put(n, file);
 					} catch (NumberFormatException e) {
-						logger.warn("Ignoring file: {}", directory);
+						logger.warn("Ignoring file: {}", file);
 						// Ignore
 					}
 				}

--- a/src/main/java/org/icatproject/core/manager/search/queue/RotatingFileQueue.java
+++ b/src/main/java/org/icatproject/core/manager/search/queue/RotatingFileQueue.java
@@ -19,20 +19,21 @@ import org.slf4j.LoggerFactory;
 
 public class RotatingFileQueue {
 
-	private static final long MAX_SIZE = 10_000_000L;
 	private static final Logger logger = LoggerFactory.getLogger(RotatingFileQueue.class);
 
 	private final Path directory;
 	private final String filename;
 	private final Path writePath;
+	private final long maxSize;
 
 	private final Object writeLock = new Object();
 	private final Object readLock = new Object();
 
-	public RotatingFileQueue(Path directory, String filename) {
+	public RotatingFileQueue(Path directory, String filename, long maxSize) {
 		this.directory = directory;
 		this.filename = filename;
 		this.writePath = directory.resolve(filename);
+		this.maxSize = maxSize;
 	}
 
 	public void synchronizedWrite(String line) throws IcatException {
@@ -60,7 +61,7 @@ public class RotatingFileQueue {
 			logger.warn("Error checking queue file size: {}", writePath, e);
 			// Ignore
 		}
-		if (size > MAX_SIZE) {
+		if (size > maxSize) {
 			logger.debug("Rotating queue file due to size {}: {}", size, writePath);
 			return true;
 		}


### PR DESCRIPTION
 - Limits the number of documents sent to icat.lucene in one go, in order to avoid timeouts
 - Commits the Lucene index after each batch of documents, in case there is a rollback in Lucene
 - Rotates the queue files if they get too big
 - Reads and writes from separate files to prevent writes timing out due to long-held locks