### PR TITLE
Fix null values being omitted from search results via SOAP interface

### DIFF
--- a/src/main/java/org/icatproject/core/entity/FieldSet.java
+++ b/src/main/java/org/icatproject/core/entity/FieldSet.java
@@ -6,7 +6,7 @@ import java.io.Serializable;
 
 @XmlRootElement
 public class FieldSet implements Serializable {
-    @XmlElement(name = "fields")
+    @XmlElement(name = "fields", nillable = true)
     private Object[] fields;
 
     public FieldSet() {

--- a/src/main/java/org/icatproject/core/entity/FieldSet.java
+++ b/src/main/java/org/icatproject/core/entity/FieldSet.java
@@ -20,8 +20,4 @@ public class FieldSet implements Serializable {
     public Object[] getFields() {
         return fields;
     }
-
-    public void setFields() {
-        this.fields = fields;
-    }
 }

--- a/src/test/java/org/icatproject/integration/TestWS.java
+++ b/src/test/java/org/icatproject/integration/TestWS.java
@@ -1856,6 +1856,10 @@ public class TestWS {
 
 		query = "SELECT f.name FROM Facility f WHERE f.name LIKE 'Test$_$_Facility' ESCAPE '$'";
 		assertEquals("Count", 1, session.search(query).size());
+
+		// Check that nulls are returned in FieldSets
+		results = session.search("SELECT null, max(i.id) FROM Investigation i");
+		assertNull(((FieldSet)results.get(0)).getFields().get(0));
 	}
 
 	@Test


### PR DESCRIPTION
When searching for a list of values (as opposed to searching for entities), the results come back as a list of `Object[]` arrays (one per row returned). These are wrapped in the `FieldSet` class so that they can be marshalled to XML in the SOAP interface. If any of the `Object[]` arrays contains `null`, the null values are discarded when marshalling.

This PR adds the `nillable=true` attribute so that null values are written to XML instead of being discarded.

Fixes #308