### PR TITLE
Add startDate and endDate fields to Instrument entity #349

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
 	<groupId>org.icatproject</groupId>
 	<artifactId>icat.server</artifactId>
-	<version>6.1.1-SNAPSHOT</version>
+	<version>6.2.0-SNAPSHOT</version>
 	<packaging>war</packaging>
 	<name>ICAT Server</name>
 	<description>A metadata catalogue to support Large Facility experimental data, 

--- a/src/main/java/org/icatproject/core/entity/Instrument.java
+++ b/src/main/java/org/icatproject/core/entity/Instrument.java
@@ -2,6 +2,7 @@ package org.icatproject.core.entity;
 
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 
 import jakarta.json.stream.JsonGenerator;
@@ -55,6 +56,12 @@ public class Instrument extends EntityBaseBean implements Serializable {
 
 	@Comment("A URL associated with this instrument")
 	private String url;
+
+	@Comment("Date when the instrument was commissioned")
+	private Date startDate;
+
+	@Comment("Date when the instrument was decommissioned")
+	private Date endDate;
 
 	@Comment("Shifts associated with this instrument")
 	@OneToMany(cascade = CascadeType.ALL, mappedBy = "instrument")
@@ -118,6 +125,14 @@ public class Instrument extends EntityBaseBean implements Serializable {
 		return this.shifts;
 	}
 
+	public Date getStartDate() {
+		return this.startDate;
+	}
+
+	public Date getEndDate() {
+		return this.endDate;
+	}
+
 	public void setDescription(String description) {
 		this.description = description;
 	}
@@ -152,6 +167,14 @@ public class Instrument extends EntityBaseBean implements Serializable {
 
 	public void setShifts(List<Shift> shifts) {
 		this.shifts = shifts;
+	}
+
+	public void setStartDate(Date startDate) {
+		this.startDate = startDate;
+	}
+
+	public void setEndDate(Date endDate) {
+		this.endDate = endDate;
 	}
 
 	@Override

--- a/src/test/java/org/icatproject/integration/TestRS.java
+++ b/src/test/java/org/icatproject/integration/TestRS.java
@@ -193,14 +193,19 @@ public class TestRS {
 		collector.checkThat(fac_response.getJsonObject(0).containsKey("Facility"), is(true));
 
 		/*
-		 * Expected: <[{"Instrument":{"id":1449,"createId":"db/notroot","createTime":
-		 * "2019-03-11T15:58:33.000Z","modId":"db/notroot","modTime":
-		 * "2019-03-11T15:58:33.000Z","fullName":"EDDI - Energy Dispersive Diffraction"
-		 * ,"instrumentScientists":[],"investigationInstruments":[],"name":"EDDI","pid":
-		 * "ig:0815","shifts":[]}}]>
-		 */
+ 		* Expected: <[{"Instrument":{"id":1449,"createId":"db/notroot","createTime":
+ 		* "2019-03-11T15:58:33.000Z","modId":"db/notroot","modTime":
+ 		* "2019-03-11T15:58:33.000Z","fullName":"EDDI - Energy Dispersive Diffraction"
+ 		* ,"instrumentScientists":[],"investigationInstruments":[],"name":"EDDI","pid":
+ 		* "ig:0815","shifts":[],"startDate":"2010-01-01T00:00:00.000Z","endDate":"2099-12-31T23:59:59.000Z"
+ 		* }}]>
+ 		*/
 		JsonArray inst_response = search(session, "SELECT i from Instrument i WHERE i.name = 'EDDI'", 1);
 		collector.checkThat(inst_response.getJsonObject(0).containsKey("Instrument"), is(true));
+		collector.checkThat(dft.parse(inst_response.getJsonObject(0).getJsonObject("Instrument")
+				.getString("startDate")), isA(Date.class));
+		collector.checkThat(dft.parse(inst_response.getJsonObject(0).getJsonObject("Instrument")
+				.getString("endDate")), isA(Date.class));
 
 		/*
 		 * Expected:

--- a/src/test/java/org/icatproject/integration/TestWS.java
+++ b/src/test/java/org/icatproject/integration/TestWS.java
@@ -71,7 +71,7 @@ import org.junit.After;
  */
 public class TestWS {
 
-	private static final String version = "6.1.";
+	private static final String version = "6.2.";
 	private static Random random;
 	private static WSession session;
 

--- a/src/test/resources/icat.port
+++ b/src/test/resources/icat.port
@@ -10,8 +10,8 @@ User (name:0, fullName:1, familyName:2, givenName:3, affiliation:4)
 Facility ( name:0, daysUntilRelease:1, createId:2, createTime:3)
 "Test port facility", 90, "Zorro", 1920-05-16T16:58:26.12Z
 
-Instrument(facility(name:0), name:1, fullName:2, pid:3)
-"Test port facility", "EDDI", "EDDI - Energy Dispersive Diffraction", "ig:0815"
+Instrument(facility(name:0), name:1, fullName:2, pid:3, startDate:4, endDate:5)
+"Test port facility", "EDDI", "EDDI - Energy Dispersive Diffraction", "ig:0815", 2010-01-01T00:00:00Z, 2099-12-31T23:59:59Z
 
 InvestigationType (facility(name:0), name:1)
 "Test port facility", "atype"


### PR DESCRIPTION
Add `startDate` & `endDate` fields to the `Instrument` entity to track instrument operational periods. These fields allow facilities to document when instruments began service and when they were decommissioned or are scheduled to end operation.

Close #349 