### PR TITLE
Move checkJPQL out of GateKeeper

### DIFF
--- a/src/main/java/org/icatproject/core/entity/Rule.java
+++ b/src/main/java/org/icatproject/core/entity/Rule.java
@@ -27,6 +27,7 @@ import org.icatproject.core.oldparser.OldSearchQuery;
 import org.icatproject.core.oldparser.OldTokenizer;
 import org.icatproject.core.parser.ParserException;
 import org.icatproject.core.parser.RuleWhat;
+import org.icatproject.core.utils.JpqlChecker;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -146,7 +147,7 @@ public class Rule extends EntityBaseBean implements Serializable {
 			logger.debug("New style rule: " + query);
 		} else {
 			/* This should be pure JPQL so can check it */
-			gateKeeper.checkJPQL(query);
+			JpqlChecker.checkJPQL(query, manager);
 		}
 
 		RuleWhat rw;

--- a/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
+++ b/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
@@ -89,6 +89,7 @@ import org.icatproject.core.parser.ParserException;
 import org.icatproject.core.parser.SearchQuery;
 import org.icatproject.core.parser.Token;
 import org.icatproject.core.parser.Tokenizer;
+import org.icatproject.core.utils.JpqlChecker;
 import org.icatproject.utils.IcatSecurity;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1023,7 +1024,7 @@ public class EntityBeanManager {
 					sb.append(token.getValue());
 					token = input.consume();
 				}
-				gateKeeper.checkJPQL(sb.toString());
+				JpqlChecker.checkJPQL(sb.toString(), manager);
 
 			} catch (ParserException e1) {
 				throw new IcatException(IcatException.IcatExceptionType.INTERNAL,

--- a/src/main/java/org/icatproject/core/manager/GateKeeper.java
+++ b/src/main/java/org/icatproject/core/manager/GateKeeper.java
@@ -15,8 +15,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
@@ -27,7 +25,6 @@ import jakarta.jms.JMSException;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -64,12 +61,6 @@ public class GateKeeper {
 			}
 		}
 	};
-
-	private final static Pattern tsRegExp = Pattern
-			.compile("\\{\\s*ts\\s+\\d{4}-\\d{2}-\\d{2}\\s+\\d{2}:\\d{2}:\\d{2}\\s*\\}");
-
-	@PersistenceContext(unitName = "icat")
-	private EntityManager gateKeeperManager;
 
 	private final Logger logger = LoggerFactory.getLogger(GateKeeper.class);
 	Marker fatal = MarkerFactory.getMarker("FATAL");
@@ -119,26 +110,6 @@ public class GateKeeper {
 		}
 
 		return false;
-	}
-
-	public void checkJPQL(String query) throws IcatException {
-
-		Matcher m = tsRegExp.matcher(query);
-
-		query = m.replaceAll(" CURRENT_TIMESTAMP ");
-		try {
-			gateKeeperManager.createQuery(query);
-		} catch (Exception e) {
-			m.reset();
-			if (m.find()) {
-				throw new IcatException(IcatExceptionType.BAD_PARAMETER,
-						"Timestamp literals have been replaced... " + e.getMessage());
-			} else {
-				throw new IcatException(IcatExceptionType.BAD_PARAMETER, e.getMessage());
-			}
-
-		}
-
 	}
 
 	@PreDestroy()

--- a/src/main/java/org/icatproject/core/utils/JpqlChecker.java
+++ b/src/main/java/org/icatproject/core/utils/JpqlChecker.java
@@ -1,0 +1,35 @@
+package org.icatproject.core.utils;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import jakarta.persistence.EntityManager;
+
+import org.icatproject.core.IcatException;
+import org.icatproject.core.IcatException.IcatExceptionType;
+
+public class JpqlChecker {
+
+	// Pattern that matches the timestamp format accepted by Icat
+	private static final Pattern TS_PATTERN = Pattern.compile("\\{\\s*ts\\s+\\d{4}-\\d{2}-\\d{2}\\s+\\d{2}:\\d{2}:\\d{2}\\s*\\}");
+
+	public static void checkJPQL(String query, EntityManager entityManager) throws IcatException {
+
+		// Icat does not accept the JDBC standard timestamp format (Icat's format is without quotes). Therefore, we
+		// must replace any timestamps before checking whether the query is valid JPQL, because the timestamps will not
+		// be valid JPQL.
+		Matcher m = TS_PATTERN.matcher(query);
+		query = m.replaceAll(" CURRENT_TIMESTAMP ");
+
+		try {
+			entityManager.createQuery(query);
+		} catch (IllegalArgumentException e) {
+			m.reset();
+			if (m.find()) {
+				throw new IcatException(IcatExceptionType.BAD_PARAMETER, "Timestamp literals have been replaced... " + e.getMessage());
+			} else {
+				throw new IcatException(IcatExceptionType.BAD_PARAMETER, e.getMessage());
+			}
+		}
+	}
+}


### PR DESCRIPTION
I seems it was only in GateKeeper to make use of the EntityManager in that class, however it is only called from methods that have access to an EnitityManger, so it can go anywhere. It is moved into its own class instead of trying to shoehorn it into an existing class.

~~The logic in checkJPQL that replaced timestamp literals has been removed because there is no good reason for it, and potentially could result in invalid JPQL passing if the regex was wrong.~~

I've added a comment explaining why timestamp literals are replaced before checking.