### PR TITLE
Remove EntityManager/UserTransaction/EJBs from some method signatures and standardise EntityManager variable name

### DIFF
--- a/src/main/java/org/icatproject/core/entity/DataCollectionParameter.java
+++ b/src/main/java/org/icatproject/core/entity/DataCollectionParameter.java
@@ -32,8 +32,8 @@ public class DataCollectionParameter extends Parameter implements Serializable {
 	}
 
 	@Override
-	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode) throws IcatException {
-		super.preparePersist(modId, manager, persistMode);
+	public void preparePersist(String modId, EntityManager entityManager, PersistMode persistMode) throws IcatException {
+		super.preparePersist(modId, entityManager, persistMode);
 		if (!type.isApplicableToDataCollection()) { // type has been checked as
 													// not null by super
 													// call

--- a/src/main/java/org/icatproject/core/entity/DataCollectionParameter.java
+++ b/src/main/java/org/icatproject/core/entity/DataCollectionParameter.java
@@ -11,7 +11,6 @@ import jakarta.persistence.UniqueConstraint;
 
 import org.icatproject.core.IcatException;
 import org.icatproject.core.manager.EntityBeanManager.PersistMode;
-import org.icatproject.core.manager.GateKeeper;
 
 @Comment("A parameter associated with a DataCollection")
 @SuppressWarnings("serial")
@@ -33,9 +32,8 @@ public class DataCollectionParameter extends Parameter implements Serializable {
 	}
 
 	@Override
-	public void preparePersist(String modId, EntityManager manager, GateKeeper gateKeeper, PersistMode persistMode)
-			throws IcatException {
-		super.preparePersist(modId, manager, gateKeeper, persistMode);
+	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode) throws IcatException {
+		super.preparePersist(modId, manager, persistMode);
 		if (!type.isApplicableToDataCollection()) { // type has been checked as
 													// not null by super
 													// call

--- a/src/main/java/org/icatproject/core/entity/Datafile.java
+++ b/src/main/java/org/icatproject/core/entity/Datafile.java
@@ -202,7 +202,7 @@ public class Datafile extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		SearchApi.encodeString(gen, "name", name);
 		SearchApi.encodeNullableString(gen, "description", description);
 		SearchApi.encodeNullableString(gen, "location", location);
@@ -211,9 +211,9 @@ public class Datafile extends EntityBaseBean implements Serializable {
 		SearchApi.encodeLong(gen, "fileCount", 1L); // Always 1, but makes sorting on fields consistent
 		if (datafileFormat != null) {
 			if (datafileFormat.getName() == null) {
-				datafileFormat = manager.find(datafileFormat.getClass(), datafileFormat.id);
+				datafileFormat = entityManager.find(datafileFormat.getClass(), datafileFormat.id);
 			}
-			datafileFormat.getDoc(manager, gen);
+			datafileFormat.getDoc(entityManager, gen);
 		}
 		if (datafileModTime != null) {
 			SearchApi.encodeLong(gen, "date", datafileModTime);
@@ -226,22 +226,22 @@ public class Datafile extends EntityBaseBean implements Serializable {
 
 		if (dataset != null) {
 			if (dataset.getName() == null || dataset.getInvestigation() == null) {
-				dataset = manager.find(dataset.getClass(), dataset.id);
+				dataset = entityManager.find(dataset.getClass(), dataset.id);
 			}
 			SearchApi.encodeLong(gen, "dataset.id", dataset.id);
 			SearchApi.encodeString(gen, "dataset.name", dataset.getName());
 			Sample sample = dataset.getSample();
 			if (sample != null) {
 				if (sample.getName() == null) {
-					sample = manager.find(sample.getClass(), sample.id);
+					sample = entityManager.find(sample.getClass(), sample.id);
 				}
-				sample.getDoc(manager, gen);
+				sample.getDoc(entityManager, gen);
 			}
 			Investigation investigation = dataset.getInvestigation();
 			if (investigation != null) {
 				if (investigation.getName() == null || investigation.getVisitId() == null
 						|| investigation.getTitle() == null || investigation.getCreateTime() == null) {
-					investigation = manager.find(investigation.getClass(), investigation.id);
+					investigation = entityManager.find(investigation.getClass(), investigation.id);
 				}
 				SearchApi.encodeLong(gen, "investigation.id", investigation.id);
 				SearchApi.encodeString(gen, "investigation.name", investigation.getName());

--- a/src/main/java/org/icatproject/core/entity/DatafileFormat.java
+++ b/src/main/java/org/icatproject/core/entity/DatafileFormat.java
@@ -106,7 +106,7 @@ public class DatafileFormat extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		SearchApi.encodeString(gen, "datafileFormat.name", name);
 		SearchApi.encodeLong(gen, "datafileFormat.id", id);
 	}

--- a/src/main/java/org/icatproject/core/entity/DatafileParameter.java
+++ b/src/main/java/org/icatproject/core/entity/DatafileParameter.java
@@ -36,8 +36,8 @@ public class DatafileParameter extends Parameter implements Serializable {
 	}
 
 	@Override
-	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode) throws IcatException {
-		super.preparePersist(modId, manager, persistMode);
+	public void preparePersist(String modId, EntityManager entityManager, PersistMode persistMode) throws IcatException {
+		super.preparePersist(modId, entityManager, persistMode);
 		if (type == null) {
 			throw new IcatException(IcatException.IcatExceptionType.VALIDATION, "Type of parameter is not set");
 		}
@@ -52,8 +52,8 @@ public class DatafileParameter extends Parameter implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
-		super.getDoc(manager, gen);
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
+		super.getDoc(entityManager, gen);
 		SearchApi.encodeLong(gen, "datafile.id", datafile.id);
 	}
 

--- a/src/main/java/org/icatproject/core/entity/DatafileParameter.java
+++ b/src/main/java/org/icatproject/core/entity/DatafileParameter.java
@@ -14,7 +14,6 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import org.icatproject.core.IcatException;
 import org.icatproject.core.manager.EntityBeanManager.PersistMode;
 import org.icatproject.core.manager.search.SearchApi;
-import org.icatproject.core.manager.GateKeeper;
 
 @Comment("A parameter associated with a data file")
 @SuppressWarnings("serial")
@@ -37,9 +36,8 @@ public class DatafileParameter extends Parameter implements Serializable {
 	}
 
 	@Override
-	public void preparePersist(String modId, EntityManager manager, GateKeeper gateKeeper, PersistMode persistMode)
-			throws IcatException {
-		super.preparePersist(modId, manager, gateKeeper, persistMode);
+	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode) throws IcatException {
+		super.preparePersist(modId, manager, persistMode);
 		if (type == null) {
 			throw new IcatException(IcatException.IcatExceptionType.VALIDATION, "Type of parameter is not set");
 		}

--- a/src/main/java/org/icatproject/core/entity/Dataset.java
+++ b/src/main/java/org/icatproject/core/entity/Dataset.java
@@ -234,7 +234,7 @@ public class Dataset extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		SearchApi.encodeString(gen, "name", name);
 		SearchApi.encodeNullableString(gen, "description", description);
 		SearchApi.encodeNullableString(gen, "doi", doi);
@@ -256,7 +256,7 @@ public class Dataset extends EntityBaseBean implements Serializable {
 		if (investigation != null) {
 			if (investigation.getName() == null || investigation.getVisitId() == null
 					|| investigation.getTitle() == null || investigation.getCreateTime() == null) {
-				investigation = manager.find(investigation.getClass(), investigation.id);
+				investigation = entityManager.find(investigation.getClass(), investigation.id);
 			}
 			SearchApi.encodeLong(gen, "investigation.id", investigation.id);
 			SearchApi.encodeString(gen, "investigation.name", investigation.getName());
@@ -271,15 +271,15 @@ public class Dataset extends EntityBaseBean implements Serializable {
 
 		if (sample != null) {
 			if (sample.getName() == null) {
-				sample = manager.find(sample.getClass(), sample.id);
+				sample = entityManager.find(sample.getClass(), sample.id);
 			}
-			sample.getDoc(manager, gen);
+			sample.getDoc(entityManager, gen);
 		}
 
 		if (type.getName() == null) {
-			type = manager.find(type.getClass(), type.id);
+			type = entityManager.find(type.getClass(), type.id);
 		}
-		type.getDoc(manager, gen);
+		type.getDoc(entityManager, gen);
 	}
 
 	/**

--- a/src/main/java/org/icatproject/core/entity/DatasetParameter.java
+++ b/src/main/java/org/icatproject/core/entity/DatasetParameter.java
@@ -14,7 +14,6 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import org.icatproject.core.IcatException;
 import org.icatproject.core.manager.EntityBeanManager.PersistMode;
 import org.icatproject.core.manager.search.SearchApi;
-import org.icatproject.core.manager.GateKeeper;
 
 @Comment("A parameter associated with a data set")
 @SuppressWarnings("serial")
@@ -37,9 +36,8 @@ public class DatasetParameter extends Parameter implements Serializable {
 	}
 
 	@Override
-	public void preparePersist(String modId, EntityManager manager, GateKeeper gateKeeper, PersistMode persistMode)
-			throws IcatException {
-		super.preparePersist(modId, manager, gateKeeper, persistMode);
+	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode) throws IcatException {
+		super.preparePersist(modId, manager, persistMode);
 		if (type == null) {
 			throw new IcatException(IcatException.IcatExceptionType.VALIDATION, "Type of parameter is not set");
 		}

--- a/src/main/java/org/icatproject/core/entity/DatasetParameter.java
+++ b/src/main/java/org/icatproject/core/entity/DatasetParameter.java
@@ -36,8 +36,8 @@ public class DatasetParameter extends Parameter implements Serializable {
 	}
 
 	@Override
-	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode) throws IcatException {
-		super.preparePersist(modId, manager, persistMode);
+	public void preparePersist(String modId, EntityManager entityManager, PersistMode persistMode) throws IcatException {
+		super.preparePersist(modId, entityManager, persistMode);
 		if (type == null) {
 			throw new IcatException(IcatException.IcatExceptionType.VALIDATION, "Type of parameter is not set");
 		}
@@ -52,8 +52,8 @@ public class DatasetParameter extends Parameter implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
-		super.getDoc(manager, gen);
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
+		super.getDoc(entityManager, gen);
 		SearchApi.encodeLong(gen, "dataset.id", dataset.id);
 	}
 }

--- a/src/main/java/org/icatproject/core/entity/DatasetTechnique.java
+++ b/src/main/java/org/icatproject/core/entity/DatasetTechnique.java
@@ -45,12 +45,12 @@ public class DatasetTechnique extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		SearchApi.encodeLong(gen, "id", id);
 		SearchApi.encodeLong(gen, "dataset.id", dataset.id);
 		if (technique.getName() == null) {
-			technique = manager.find(technique.getClass(), technique.id);
+			technique = entityManager.find(technique.getClass(), technique.id);
 		}
-		technique.getDoc(manager, gen);
+		technique.getDoc(entityManager, gen);
 	}
 }

--- a/src/main/java/org/icatproject/core/entity/DatasetType.java
+++ b/src/main/java/org/icatproject/core/entity/DatasetType.java
@@ -82,7 +82,7 @@ public class DatasetType extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		SearchApi.encodeString(gen, "type.name", name);
 		SearchApi.encodeLong(gen, "type.id", id);
 	}

--- a/src/main/java/org/icatproject/core/entity/EntityBaseBean.java
+++ b/src/main/java/org/icatproject/core/entity/EntityBaseBean.java
@@ -237,7 +237,7 @@ public abstract class EntityBaseBean implements HasEntityId, Serializable {
 	 * If this method is overridden it should normally be called as well by
 	 * super.postMergeFixup()
 	 */
-	public void postMergeFixup(EntityManager manager, GateKeeper gateKeeper) throws IcatException {
+	public void postMergeFixup(EntityManager manager) throws IcatException {
 		// Do nothing by default
 	}
 
@@ -246,8 +246,7 @@ public abstract class EntityBaseBean implements HasEntityId, Serializable {
 	 * super.preparePersist(). Note that it recurses down through all to-many
 	 * relationships.
 	 */
-	public void preparePersist(String modId, EntityManager manager, GateKeeper gateKeeper, PersistMode persistMode)
-			throws IcatException {
+	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode) throws IcatException {
 
 		logger.trace("preparePersist of " + this + " for state " + persistMode);
 
@@ -317,7 +316,7 @@ public abstract class EntityBaseBean implements HasEntityId, Serializable {
 					if (!collection.isEmpty()) {
 						Method rev = r.getInverseSetter();
 						for (EntityBaseBean bean : collection) {
-							bean.preparePersist(modId, manager, gateKeeper, persistMode);
+							bean.preparePersist(modId, manager, persistMode);
 							rev.invoke(bean, this);
 						}
 					}

--- a/src/main/java/org/icatproject/core/entity/EntityBaseBean.java
+++ b/src/main/java/org/icatproject/core/entity/EntityBaseBean.java
@@ -80,8 +80,8 @@ public abstract class EntityBaseBean implements HasEntityId, Serializable {
 
 	// This is only used by the older create and createMany calls and not by the
 	// new Restful write call
-	public void addToSearch(EntityManager manager, SearchManager searchManager) throws IcatException {
-		searchManager.addDocument(manager, this);
+	public void addToSearch(EntityManager entityManager, SearchManager searchManager) throws IcatException {
+		searchManager.addDocument(entityManager, this);
 		Class<? extends EntityBaseBean> klass = this.getClass();
 		Set<Relationship> rs = EntityInfoHandler.getRelatedEntities(klass);
 		Map<Field, Method> getters = EntityInfoHandler.getGetters(klass);
@@ -93,7 +93,7 @@ public abstract class EntityBaseBean implements HasEntityId, Serializable {
 					List<EntityBaseBean> collection = (List<EntityBaseBean>) m.invoke(this);
 					if (!collection.isEmpty()) {
 						for (EntityBaseBean bean : collection) {
-							bean.addToSearch(manager, searchManager);
+							bean.addToSearch(entityManager, searchManager);
 						}
 					}
 				} catch (Exception e) {
@@ -234,7 +234,7 @@ public abstract class EntityBaseBean implements HasEntityId, Serializable {
 	 * If this method is overridden it should normally be called as well by
 	 * super.postMergeFixup()
 	 */
-	public void postMergeFixup(EntityManager manager) throws IcatException {
+	public void postMergeFixup(EntityManager entityManager) throws IcatException {
 		// Do nothing by default
 	}
 
@@ -243,7 +243,7 @@ public abstract class EntityBaseBean implements HasEntityId, Serializable {
 	 * super.preparePersist(). Note that it recurses down through all to-many
 	 * relationships.
 	 */
-	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode) throws IcatException {
+	public void preparePersist(String modId, EntityManager entityManager, PersistMode persistMode) throws IcatException {
 
 		logger.trace("preparePersist of " + this + " for state " + persistMode);
 
@@ -313,7 +313,7 @@ public abstract class EntityBaseBean implements HasEntityId, Serializable {
 					if (!collection.isEmpty()) {
 						Method rev = r.getInverseSetter();
 						for (EntityBaseBean bean : collection) {
-							bean.preparePersist(modId, manager, persistMode);
+							bean.preparePersist(modId, entityManager, persistMode);
 							rev.invoke(bean, this);
 						}
 					}
@@ -430,7 +430,7 @@ public abstract class EntityBaseBean implements HasEntityId, Serializable {
 	 * This should be overridden by classes wishing to index things in a search
 	 * engine
 	 */
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 	}
 
 }

--- a/src/main/java/org/icatproject/core/entity/Facility.java
+++ b/src/main/java/org/icatproject/core/entity/Facility.java
@@ -210,7 +210,7 @@ public class Facility extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		SearchApi.encodeString(gen, "facility.name", name);
 		SearchApi.encodeLong(gen, "facility.id", id);
 	}

--- a/src/main/java/org/icatproject/core/entity/Instrument.java
+++ b/src/main/java/org/icatproject/core/entity/Instrument.java
@@ -155,7 +155,7 @@ public class Instrument extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		SearchApi.encodeNullableString(gen, "instrument.fullName", fullName);
 		SearchApi.encodeString(gen, "instrument.name", name);
 		SearchApi.encodeLong(gen, "instrument.id", id);

--- a/src/main/java/org/icatproject/core/entity/InstrumentScientist.java
+++ b/src/main/java/org/icatproject/core/entity/InstrumentScientist.java
@@ -49,11 +49,11 @@ public class InstrumentScientist extends EntityBaseBean implements Serializable 
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		if (user.getName() == null) {
-			user = manager.find(user.getClass(), user.id);
+			user = entityManager.find(user.getClass(), user.id);
 		}
-		user.getDoc(manager, gen);
+		user.getDoc(entityManager, gen);
 		SearchApi.encodeLong(gen, "instrument.id", instrument.id);
 		SearchApi.encodeLong(gen, "id", id);
 	}

--- a/src/main/java/org/icatproject/core/entity/Investigation.java
+++ b/src/main/java/org/icatproject/core/entity/Investigation.java
@@ -321,7 +321,7 @@ public class Investigation extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		SearchApi.encodeString(gen, "name", name);
 		SearchApi.encodeString(gen, "visitId", visitId);
 		SearchApi.encodeString(gen, "title", title);
@@ -347,14 +347,14 @@ public class Investigation extends EntityBaseBean implements Serializable {
 		SearchApi.encodeLong(gen, "id", id);
 
 		if (facility.getName() == null) {
-			facility = manager.find(facility.getClass(), facility.id);
+			facility = entityManager.find(facility.getClass(), facility.id);
 		}
-		facility.getDoc(manager, gen);
+		facility.getDoc(entityManager, gen);
 
 		if (type.getName() == null) {
-			type = manager.find(type.getClass(), type.id);
+			type = entityManager.find(type.getClass(), type.id);
 		}
-		type.getDoc(manager, gen);
+		type.getDoc(entityManager, gen);
 	}
 
 	/**

--- a/src/main/java/org/icatproject/core/entity/InvestigationFacilityCycle.java
+++ b/src/main/java/org/icatproject/core/entity/InvestigationFacilityCycle.java
@@ -49,7 +49,7 @@ public class InvestigationFacilityCycle extends EntityBaseBean implements Serial
     }
 
     @Override
-    public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+    public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
         SearchApi.encodeLong(gen, "facilityCycle.id", facilityCycle.id);
         SearchApi.encodeLong(gen, "investigation.id", investigation.id);
         SearchApi.encodeLong(gen, "id", id);

--- a/src/main/java/org/icatproject/core/entity/InvestigationInstrument.java
+++ b/src/main/java/org/icatproject/core/entity/InvestigationInstrument.java
@@ -45,11 +45,11 @@ public class InvestigationInstrument extends EntityBaseBean implements Serializa
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		if (instrument.getName() == null) {
-			instrument = manager.find(instrument.getClass(), instrument.id);
+			instrument = entityManager.find(instrument.getClass(), instrument.id);
 		}
-		instrument.getDoc(manager, gen);
+		instrument.getDoc(entityManager, gen);
 		SearchApi.encodeLong(gen, "investigation.id", investigation.id);
 		SearchApi.encodeLong(gen, "id", id);
 	}

--- a/src/main/java/org/icatproject/core/entity/InvestigationParameter.java
+++ b/src/main/java/org/icatproject/core/entity/InvestigationParameter.java
@@ -14,7 +14,6 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import org.icatproject.core.IcatException;
 import org.icatproject.core.manager.EntityBeanManager.PersistMode;
 import org.icatproject.core.manager.search.SearchApi;
-import org.icatproject.core.manager.GateKeeper;
 
 @Comment("A parameter associated with an investigation")
 @SuppressWarnings("serial")
@@ -37,9 +36,8 @@ public class InvestigationParameter extends Parameter implements Serializable {
 	}
 
 	@Override
-	public void preparePersist(String modId, EntityManager manager, GateKeeper gateKeeper, PersistMode persistMode)
-			throws IcatException {
-		super.preparePersist(modId, manager, gateKeeper, persistMode);
+	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode) throws IcatException {
+		super.preparePersist(modId, manager, persistMode);
 		this.id = null;
 		if (type == null) {
 			throw new IcatException(IcatException.IcatExceptionType.VALIDATION, "Type of parameter is not set");

--- a/src/main/java/org/icatproject/core/entity/InvestigationParameter.java
+++ b/src/main/java/org/icatproject/core/entity/InvestigationParameter.java
@@ -36,8 +36,8 @@ public class InvestigationParameter extends Parameter implements Serializable {
 	}
 
 	@Override
-	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode) throws IcatException {
-		super.preparePersist(modId, manager, persistMode);
+	public void preparePersist(String modId, EntityManager entityManager, PersistMode persistMode) throws IcatException {
+		super.preparePersist(modId, entityManager, persistMode);
 		this.id = null;
 		if (type == null) {
 			throw new IcatException(IcatException.IcatExceptionType.VALIDATION, "Type of parameter is not set");
@@ -53,8 +53,8 @@ public class InvestigationParameter extends Parameter implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
-		super.getDoc(manager, gen);
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
+		super.getDoc(entityManager, gen);
 		SearchApi.encodeLong(gen, "investigation.id", investigation.id);
 	}
 }

--- a/src/main/java/org/icatproject/core/entity/InvestigationType.java
+++ b/src/main/java/org/icatproject/core/entity/InvestigationType.java
@@ -82,7 +82,7 @@ public class InvestigationType extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		SearchApi.encodeString(gen, "type.name", name);
 		SearchApi.encodeLong(gen, "type.id", id);
 	}

--- a/src/main/java/org/icatproject/core/entity/InvestigationUser.java
+++ b/src/main/java/org/icatproject/core/entity/InvestigationUser.java
@@ -40,11 +40,11 @@ public class InvestigationUser extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		if (user.getName() == null) {
-			user = manager.find(user.getClass(), user.id);
+			user = entityManager.find(user.getClass(), user.id);
 		}
-		user.getDoc(manager, gen);
+		user.getDoc(entityManager, gen);
 		SearchApi.encodeLong(gen, "investigation.id", investigation.id);
 		SearchApi.encodeLong(gen, "id", id);
 	}

--- a/src/main/java/org/icatproject/core/entity/Parameter.java
+++ b/src/main/java/org/icatproject/core/entity/Parameter.java
@@ -114,13 +114,13 @@ public abstract class Parameter extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode)
+	public void preparePersist(String modId, EntityManager entityManager, PersistMode persistMode)
 			throws IcatException {
-		super.preparePersist(modId, manager, persistMode);
-		check(manager);
+		super.preparePersist(modId, entityManager, persistMode);
+		check(entityManager);
 	}
 
-	private void check(EntityManager manager) throws IcatException {
+	private void check(EntityManager entityManager) throws IcatException {
 		if (type == null) {
 			throw new IcatException(IcatException.IcatExceptionType.VALIDATION, "Type of parameter is not set");
 		}
@@ -145,7 +145,7 @@ public abstract class Parameter extends EntityBaseBean implements Serializable {
 			logger.debug("Parameter of type " + type.getName() + " has string value " + stringValue + " to be checked");
 			// The query is used because the ParameterType passed in may not
 			// include its PermissibleStringValues
-			List<String> values = manager.createNamedQuery("Parameter.psv", String.class)
+			List<String> values = entityManager.createNamedQuery("Parameter.psv", String.class)
 					.setParameter("tid", type.getId()).getResultList();
 			if (!values.isEmpty() && values.indexOf(stringValue) < 0) {
 				throw new IcatException(IcatException.IcatExceptionType.VALIDATION, "Parameter of type "
@@ -155,13 +155,13 @@ public abstract class Parameter extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void postMergeFixup(EntityManager manager) throws IcatException {
-		super.postMergeFixup(manager);
-		check(manager);
+	public void postMergeFixup(EntityManager entityManager) throws IcatException {
+		super.postMergeFixup(entityManager);
+		check(entityManager);
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		if (stringValue != null) {
 			SearchApi.encodeString(gen, "stringValue", stringValue);
 		} else if (numericValue != null) {
@@ -177,9 +177,9 @@ public abstract class Parameter extends EntityBaseBean implements Serializable {
 		}
 
 		if (type.getName() == null || type.getUnits() == null) {
-			type = manager.find(type.getClass(), type.id);
+			type = entityManager.find(type.getClass(), type.id);
 		}
-		type.getDoc(manager, gen);
+		type.getDoc(entityManager, gen);
 		SearchApi.encodeLong(gen, "id", id);
 	}
 

--- a/src/main/java/org/icatproject/core/entity/Parameter.java
+++ b/src/main/java/org/icatproject/core/entity/Parameter.java
@@ -17,7 +17,6 @@ import jakarta.persistence.TemporalType;
 import org.icatproject.core.IcatException;
 import org.icatproject.core.manager.EntityBeanManager.PersistMode;
 import org.icatproject.core.manager.search.SearchApi;
-import org.icatproject.core.manager.GateKeeper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -115,9 +114,9 @@ public abstract class Parameter extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void preparePersist(String modId, EntityManager manager, GateKeeper gateKeeper, PersistMode persistMode)
+	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode)
 			throws IcatException {
-		super.preparePersist(modId, manager, gateKeeper, persistMode);
+		super.preparePersist(modId, manager, persistMode);
 		check(manager);
 	}
 
@@ -156,8 +155,8 @@ public abstract class Parameter extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void postMergeFixup(EntityManager manager, GateKeeper gateKeeper) throws IcatException {
-		super.postMergeFixup(manager, gateKeeper);
+	public void postMergeFixup(EntityManager manager) throws IcatException {
+		super.postMergeFixup(manager);
 		check(manager);
 	}
 

--- a/src/main/java/org/icatproject/core/entity/ParameterType.java
+++ b/src/main/java/org/icatproject/core/entity/ParameterType.java
@@ -283,7 +283,7 @@ public class ParameterType extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		SearchApi.encodeString(gen, "type.name", name);
 		SearchApi.encodeString(gen, "type.units", units);
 		SearchApi.encodeLong(gen, "type.id", id);

--- a/src/main/java/org/icatproject/core/entity/PublicStep.java
+++ b/src/main/java/org/icatproject/core/entity/PublicStep.java
@@ -59,7 +59,7 @@ public class PublicStep extends EntityBaseBean implements Serializable {
 	public PublicStep() {
 	}
 
-	private void fixup(EntityManager entityManager) throws IcatException {
+	private void fixup() throws IcatException {
 		Class<? extends EntityBaseBean> bean = EntityInfoHandler.getClass(origin);
 		Set<Relationship> rs = EntityInfoHandler.getRelatedEntities(bean);
 		boolean found = false;
@@ -78,14 +78,14 @@ public class PublicStep extends EntityBaseBean implements Serializable {
 	@Override
 	public void postMergeFixup(EntityManager entityManager) throws IcatException {
 		super.postMergeFixup(entityManager);
-		this.fixup(entityManager);
+		this.fixup();
 	}
 
 	@Override
 	public void preparePersist(String modId, EntityManager entityManager, PersistMode persistMode)
 			throws IcatException {
 		super.preparePersist(modId, entityManager, persistMode);
-		this.fixup(entityManager);
+		this.fixup();
 	}
 
 	@PostRemove()

--- a/src/main/java/org/icatproject/core/entity/PublicStep.java
+++ b/src/main/java/org/icatproject/core/entity/PublicStep.java
@@ -15,7 +15,6 @@ import jakarta.persistence.UniqueConstraint;
 import org.icatproject.core.IcatException;
 import org.icatproject.core.manager.EntityInfoHandler;
 import org.icatproject.core.manager.EntityInfoHandler.Relationship;
-import org.icatproject.core.manager.GateKeeper;
 import org.icatproject.core.manager.SingletonFinder;
 import org.icatproject.core.manager.EntityBeanManager.PersistMode;
 import org.slf4j.Logger;
@@ -60,7 +59,7 @@ public class PublicStep extends EntityBaseBean implements Serializable {
 	public PublicStep() {
 	}
 
-	private void fixup(EntityManager manager, GateKeeper gateKeeper) throws IcatException {
+	private void fixup(EntityManager manager) throws IcatException {
 		Class<? extends EntityBaseBean> bean = EntityInfoHandler.getClass(origin);
 		Set<Relationship> rs = EntityInfoHandler.getRelatedEntities(bean);
 		boolean found = false;
@@ -77,16 +76,16 @@ public class PublicStep extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void postMergeFixup(EntityManager manager, GateKeeper gateKeeper) throws IcatException {
-		super.postMergeFixup(manager, gateKeeper);
-		this.fixup(manager, gateKeeper);
+	public void postMergeFixup(EntityManager manager) throws IcatException {
+		super.postMergeFixup(manager);
+		this.fixup(manager);
 	}
 
 	@Override
-	public void preparePersist(String modId, EntityManager manager, GateKeeper gateKeeper, PersistMode persistMode)
+	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode)
 			throws IcatException {
-		super.preparePersist(modId, manager, gateKeeper, persistMode);
-		this.fixup(manager, gateKeeper);
+		super.preparePersist(modId, manager, persistMode);
+		this.fixup(manager);
 	}
 
 	@PostRemove()

--- a/src/main/java/org/icatproject/core/entity/PublicStep.java
+++ b/src/main/java/org/icatproject/core/entity/PublicStep.java
@@ -59,7 +59,7 @@ public class PublicStep extends EntityBaseBean implements Serializable {
 	public PublicStep() {
 	}
 
-	private void fixup(EntityManager manager) throws IcatException {
+	private void fixup(EntityManager entityManager) throws IcatException {
 		Class<? extends EntityBaseBean> bean = EntityInfoHandler.getClass(origin);
 		Set<Relationship> rs = EntityInfoHandler.getRelatedEntities(bean);
 		boolean found = false;
@@ -76,16 +76,16 @@ public class PublicStep extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void postMergeFixup(EntityManager manager) throws IcatException {
-		super.postMergeFixup(manager);
-		this.fixup(manager);
+	public void postMergeFixup(EntityManager entityManager) throws IcatException {
+		super.postMergeFixup(entityManager);
+		this.fixup(entityManager);
 	}
 
 	@Override
-	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode)
+	public void preparePersist(String modId, EntityManager entityManager, PersistMode persistMode)
 			throws IcatException {
-		super.preparePersist(modId, manager, persistMode);
-		this.fixup(manager);
+		super.preparePersist(modId, entityManager, persistMode);
+		this.fixup(entityManager);
 	}
 
 	@PostRemove()

--- a/src/main/java/org/icatproject/core/entity/Rule.java
+++ b/src/main/java/org/icatproject/core/entity/Rule.java
@@ -110,7 +110,7 @@ public class Rule extends EntityBaseBean implements Serializable {
 	public Rule() {
 	}
 
-	private void fixup(EntityManager manager, GateKeeper gateKeeper) throws IcatException {
+	private void fixup(EntityManager manager) throws IcatException {
 		this.crudFlags = this.crudFlags.toUpperCase().trim();
 		for (int i = 0; i < this.crudFlags.length(); i++) {
 			final char ch = this.crudFlags.charAt(i);
@@ -226,13 +226,13 @@ public class Rule extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void postMergeFixup(EntityManager manager, GateKeeper gateKeeper) throws IcatException {
-		super.postMergeFixup(manager, gateKeeper);
+	public void postMergeFixup(EntityManager manager) throws IcatException {
+		super.postMergeFixup(manager);
 		this.c = false;
 		this.r = false;
 		this.u = false;
 		this.d = false;
-		this.fixup(manager, gateKeeper);
+		this.fixup(manager);
 		logger.debug("postMergeFixup of Rule for " + this.crudFlags + " of " + this.what);
 	}
 
@@ -255,10 +255,9 @@ public class Rule extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void preparePersist(String modId, EntityManager manager, GateKeeper gateKeeper, PersistMode persistMode)
-			throws IcatException {
-		super.preparePersist(modId, manager, gateKeeper, persistMode);
-		this.fixup(manager, gateKeeper);
+	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode) throws IcatException {
+		super.preparePersist(modId, manager, persistMode);
+		this.fixup(manager);
 		logger.debug("PreparePersist of Rule for " + this.crudFlags + " of " + this.what);
 	}
 

--- a/src/main/java/org/icatproject/core/entity/Rule.java
+++ b/src/main/java/org/icatproject/core/entity/Rule.java
@@ -103,7 +103,7 @@ public class Rule extends EntityBaseBean implements Serializable {
 	public Rule() {
 	}
 
-	private void fixup(EntityManager manager) throws IcatException {
+	private void fixup(EntityManager entityManager) throws IcatException {
 		this.crudFlags = this.crudFlags.toUpperCase().trim();
 		for (int i = 0; i < this.crudFlags.length(); i++) {
 			final char ch = this.crudFlags.charAt(i);
@@ -140,7 +140,7 @@ public class Rule extends EntityBaseBean implements Serializable {
 			logger.debug("New style rule: " + query);
 		} else {
 			/* This should be pure JPQL so can check it */
-			JpqlChecker.checkJPQL(query, manager);
+			JpqlChecker.checkJPQL(query, entityManager);
 		}
 
 		RuleWhat rw;
@@ -219,13 +219,13 @@ public class Rule extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void postMergeFixup(EntityManager manager) throws IcatException {
-		super.postMergeFixup(manager);
+	public void postMergeFixup(EntityManager entityManager) throws IcatException {
+		super.postMergeFixup(entityManager);
 		this.c = false;
 		this.r = false;
 		this.u = false;
 		this.d = false;
-		this.fixup(manager);
+		this.fixup(entityManager);
 		logger.debug("postMergeFixup of Rule for " + this.crudFlags + " of " + this.what);
 	}
 
@@ -248,9 +248,9 @@ public class Rule extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode) throws IcatException {
-		super.preparePersist(modId, manager, persistMode);
-		this.fixup(manager);
+	public void preparePersist(String modId, EntityManager entityManager, PersistMode persistMode) throws IcatException {
+		super.preparePersist(modId, entityManager, persistMode);
+		this.fixup(entityManager);
 		logger.debug("PreparePersist of Rule for " + this.crudFlags + " of " + this.what);
 	}
 

--- a/src/main/java/org/icatproject/core/entity/Rule.java
+++ b/src/main/java/org/icatproject/core/entity/Rule.java
@@ -2,7 +2,6 @@ package org.icatproject.core.entity;
 
 import java.io.Serializable;
 
-import jakarta.ejb.EJB;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EntityManager;
@@ -13,12 +12,10 @@ import jakarta.persistence.NamedQuery;
 import jakarta.persistence.PostPersist;
 import jakarta.persistence.PostRemove;
 import jakarta.persistence.Table;
-import jakarta.persistence.Transient;
 import jakarta.xml.bind.annotation.XmlTransient;
 
 import org.icatproject.core.IcatException;
 import org.icatproject.core.manager.EntityBeanManager.PersistMode;
-import org.icatproject.core.manager.GateKeeper;
 import org.icatproject.core.manager.SingletonFinder;
 import org.icatproject.core.oldparser.OldInput;
 import org.icatproject.core.oldparser.OldLexerException;
@@ -57,10 +54,6 @@ public class Rule extends EntityBaseBean implements Serializable {
 	public static final String UPDATE_QUERY = "Rule.UpdateQuery";
 	public static final String UPDATE_ATTRIBUTE_QUERY = "Rule.UpdateAttributeQuery";
 	public static final String PUBLIC_QUERY = "Rule.PublicQuery";
-	@EJB
-	@XmlTransient
-	@Transient
-	private GateKeeper gatekeeper;
 
 	@XmlTransient
 	private String bean;

--- a/src/main/java/org/icatproject/core/entity/Sample.java
+++ b/src/main/java/org/icatproject/core/entity/Sample.java
@@ -104,7 +104,7 @@ public class Sample extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		SearchApi.encodeString(gen, "sample.name", name);
 		SearchApi.encodeLong(gen, "sample.id", id);
 		if (investigation != null) {
@@ -115,9 +115,9 @@ public class Sample extends EntityBaseBean implements Serializable {
 		}
 		if (type != null) {
 			if (type.getName() == null) {
-				type = manager.find(type.getClass(), type.id);
+				type = entityManager.find(type.getClass(), type.id);
 			}
-			type.getDoc(manager, gen);
+			type.getDoc(entityManager, gen);
 		}
 	}
 

--- a/src/main/java/org/icatproject/core/entity/SampleParameter.java
+++ b/src/main/java/org/icatproject/core/entity/SampleParameter.java
@@ -36,8 +36,8 @@ public class SampleParameter extends Parameter implements Serializable {
 	}
 
 	@Override
-	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode) throws IcatException {
-		super.preparePersist(modId, manager, persistMode);
+	public void preparePersist(String modId, EntityManager entityManager, PersistMode persistMode) throws IcatException {
+		super.preparePersist(modId, entityManager, persistMode);
 		if (type == null) {
 			throw new IcatException(IcatException.IcatExceptionType.VALIDATION, "Type of parameter is not set");
 		}
@@ -52,8 +52,8 @@ public class SampleParameter extends Parameter implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
-		super.getDoc(manager, gen);
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
+		super.getDoc(entityManager, gen);
 		SearchApi.encodeLong(gen, "sample.id", sample.id);
 	}
 

--- a/src/main/java/org/icatproject/core/entity/SampleParameter.java
+++ b/src/main/java/org/icatproject/core/entity/SampleParameter.java
@@ -14,7 +14,6 @@ import jakarta.xml.bind.annotation.XmlRootElement;
 import org.icatproject.core.IcatException;
 import org.icatproject.core.manager.EntityBeanManager.PersistMode;
 import org.icatproject.core.manager.search.SearchApi;
-import org.icatproject.core.manager.GateKeeper;
 
 @Comment("A parameter associated with a sample")
 @SuppressWarnings("serial")
@@ -37,9 +36,8 @@ public class SampleParameter extends Parameter implements Serializable {
 	}
 
 	@Override
-	public void preparePersist(String modId, EntityManager manager, GateKeeper gateKeeper, PersistMode persistMode)
-			throws IcatException {
-		super.preparePersist(modId, manager, gateKeeper, persistMode);
+	public void preparePersist(String modId, EntityManager manager, PersistMode persistMode) throws IcatException {
+		super.preparePersist(modId, manager, persistMode);
 		if (type == null) {
 			throw new IcatException(IcatException.IcatExceptionType.VALIDATION, "Type of parameter is not set");
 		}

--- a/src/main/java/org/icatproject/core/entity/SampleType.java
+++ b/src/main/java/org/icatproject/core/entity/SampleType.java
@@ -95,7 +95,7 @@ public class SampleType extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		SearchApi.encodeString(gen, "sample.type.name", name);
 		SearchApi.encodeLong(gen, "sample.type.id", id);
 	}

--- a/src/main/java/org/icatproject/core/entity/Technique.java
+++ b/src/main/java/org/icatproject/core/entity/Technique.java
@@ -74,7 +74,7 @@ public class Technique extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		SearchApi.encodeLong(gen, "technique.id", id);
 		SearchApi.encodeString(gen, "technique.name", name);
 		SearchApi.encodeNullableString(gen, "technique.description", description);

--- a/src/main/java/org/icatproject/core/entity/User.java
+++ b/src/main/java/org/icatproject/core/entity/User.java
@@ -169,7 +169,7 @@ public class User extends EntityBaseBean implements Serializable {
 	}
 
 	@Override
-	public void getDoc(EntityManager manager, JsonGenerator gen) throws IcatException {
+	public void getDoc(EntityManager entityManager, JsonGenerator gen) throws IcatException {
 		SearchApi.encodeNullableString(gen, "user.fullName", fullName);
 		SearchApi.encodeString(gen, "user.name", name);
 		SearchApi.encodeLong(gen, "user.id", id);

--- a/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
+++ b/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
@@ -253,8 +253,7 @@ public class EntityBeanManager {
 				logger.trace(bean + " flushed.");
 				// Check authz now everything persisted
 				gateKeeper.performAuthorisation(userId, bean, AccessType.CREATE, manager);
-				NotificationMessage notification = new NotificationMessage(Operation.C, bean, manager,
-						notificationRequests);
+				NotificationMessage notification = new NotificationMessage(Operation.C, bean, notificationRequests);
 
 				long beanId = bean.getId();
 
@@ -371,8 +370,7 @@ public class EntityBeanManager {
 					logger.trace(bean + " flushed.");
 					// Check authz now everything persisted
 					gateKeeper.performAuthorisation(userId, bean, AccessType.CREATE, manager);
-					NotificationMessage notification = new NotificationMessage(Operation.C, bean, manager,
-							notificationRequests);
+					NotificationMessage notification = new NotificationMessage(Operation.C, bean, notificationRequests);
 					CreateResponse cr = new CreateResponse(bean.getId(), notification);
 					crs.add(cr);
 				}
@@ -2138,8 +2136,7 @@ public class EntityBeanManager {
 				beanManaged.postMergeFixup(manager);
 				manager.flush();
 				logger.trace("Updated bean " + bean + " flushed.");
-				NotificationMessage notification = new NotificationMessage(Operation.U, bean, manager,
-						notificationRequests);
+				NotificationMessage notification = new NotificationMessage(Operation.U, bean, notificationRequests);
 				userTransaction.commit();
 				if (logRequests.contains(CallType.WRITE)) {
 					ByteArrayOutputStream baos = new ByteArrayOutputStream();
@@ -2261,13 +2258,11 @@ public class EntityBeanManager {
 
 				try {
 					for (EntityBaseBean eb : creates) {
-						notificationTransmitter.processMessage(
-								new NotificationMessage(Operation.C, eb, manager, notificationRequests));
+						notificationTransmitter.processMessage(new NotificationMessage(Operation.C, eb, notificationRequests));
 					}
 
 					for (EntityBaseBean eb : updates) {
-						notificationTransmitter.processMessage(
-								new NotificationMessage(Operation.U, eb, manager, notificationRequests));
+						notificationTransmitter.processMessage(new NotificationMessage(Operation.U, eb, notificationRequests));
 					}
 				} catch (JMSException e) {
 					throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
@@ -2611,8 +2606,7 @@ public class EntityBeanManager {
 
 		for (EntityBaseBean c : clonedTo.values()) {
 			try {
-				notificationTransmitter
-						.processMessage(new NotificationMessage(Operation.C, c, manager, notificationRequests));
+				notificationTransmitter.processMessage(new NotificationMessage(Operation.C, c, notificationRequests));
 			} catch (JMSException e) {
 				throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
 						"Operation completed but unable to send JMS message " + e.getMessage());

--- a/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
+++ b/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
@@ -245,7 +245,7 @@ public class EntityBeanManager {
 			}
 			try {
 				long startMillis = log ? System.currentTimeMillis() : 0;
-				bean.preparePersist(userId, manager, gateKeeper, persistMode);
+				bean.preparePersist(userId, manager, persistMode);
 				logger.trace(bean + " prepared for persist.");
 				manager.persist(bean);
 				logger.trace(bean + " persisted.");
@@ -285,7 +285,7 @@ public class EntityBeanManager {
 						+ e.getMessage());
 				updateCache();
 
-				bean.preparePersist(userId, manager, gateKeeper, persistMode);
+				bean.preparePersist(userId, manager, persistMode);
 				isUnique(bean, manager);
 				isValid(bean);
 				throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
@@ -309,7 +309,7 @@ public class EntityBeanManager {
 			userTransaction.begin();
 			try {
 				try {
-					bean.preparePersist(userId, manager, gateKeeper, PersistMode.IMPORT_OR_WS);
+					bean.preparePersist(userId, manager, PersistMode.IMPORT_OR_WS);
 					logger.debug(bean + " prepared for persist (createAllowed).");
 					manager.persist(bean);
 					logger.debug(bean + " persisted (createAllowed).");
@@ -321,7 +321,7 @@ public class EntityBeanManager {
 					userTransaction.rollback();
 					logger.debug("Transaction rolled back for creation of " + bean + " because of " + e.getClass() + " "
 							+ e.getMessage());
-					bean.preparePersist(userId, manager, gateKeeper, PersistMode.IMPORT_OR_WS);
+					bean.preparePersist(userId, manager, PersistMode.IMPORT_OR_WS);
 					isUnique(bean, manager);
 					isValid(bean);
 					throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
@@ -363,7 +363,7 @@ public class EntityBeanManager {
 			try {
 				long startMillis = log ? System.currentTimeMillis() : 0;
 				for (EntityBaseBean bean : beans) {
-					bean.preparePersist(userId, manager, gateKeeper, PersistMode.IMPORT_OR_WS);
+					bean.preparePersist(userId, manager, PersistMode.IMPORT_OR_WS);
 					logger.trace(bean + " prepared for persist.");
 					manager.persist(bean);
 					logger.trace(bean + " persisted.");
@@ -411,7 +411,7 @@ public class EntityBeanManager {
 				int pos = crs.size();
 				EntityBaseBean bean = beans.get(pos);
 				try {
-					bean.preparePersist(userId, manager, gateKeeper, PersistMode.IMPORT_OR_WS);
+					bean.preparePersist(userId, manager, PersistMode.IMPORT_OR_WS);
 					isUnique(bean, manager);
 					isValid(bean);
 				} catch (IcatException e1) {
@@ -2135,7 +2135,7 @@ public class EntityBeanManager {
 				if (identityChange) {
 					gateKeeper.performAuthorisation(userId, beanManaged, AccessType.CREATE, manager);
 				}
-				beanManaged.postMergeFixup(manager, gateKeeper);
+				beanManaged.postMergeFixup(manager);
 				manager.flush();
 				logger.trace("Updated bean " + bean + " flushed.");
 				NotificationMessage notification = new NotificationMessage(Operation.U, bean, manager,
@@ -2164,7 +2164,7 @@ public class EntityBeanManager {
 				EntityBaseBean beanManaged = find(bean, manager);
 				beanManaged.setModId(userId);
 				merge(beanManaged, bean, manager);
-				beanManaged.postMergeFixup(manager, gateKeeper);
+				beanManaged.postMergeFixup(manager);
 				isValid(beanManaged);
 				logger.error("Internal error", e);
 				throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
@@ -2340,13 +2340,13 @@ public class EntityBeanManager {
 		}
 
 		try {
-			bean.preparePersist(userId, manager, gateKeeper, PersistMode.REST);
+			bean.preparePersist(userId, manager, PersistMode.REST);
 			if (create) {
 				manager.persist(bean);
 				logger.trace(bean + " persisted.");
 			}
 			for (EntityBaseBean b : localUpdates.keySet()) {
-				b.postMergeFixup(manager, gateKeeper);
+				b.postMergeFixup(manager);
 			}
 			manager.flush();
 			logger.trace(bean + " flushed.");
@@ -2533,7 +2533,7 @@ public class EntityBeanManager {
 		}
 
 		cloneOneToManys(bean, clone, klass, getters, setters, rs, manager, clonedTo, userId);
-		clone.preparePersist(userId, manager, gateKeeper, PersistMode.CLONE);
+		clone.preparePersist(userId, manager, PersistMode.CLONE);
 		logger.trace(clone + " prepared for persist.");
 
 		try {
@@ -2575,7 +2575,7 @@ public class EntityBeanManager {
 				logger.trace("Transaction rolled back for creation of " + clone + " because of " + e.getClass() + " "
 						+ e.getMessage());
 				updateCache();
-				bean.preparePersist(userId, manager, gateKeeper, PersistMode.CLONE);
+				bean.preparePersist(userId, manager, PersistMode.CLONE);
 				isUnique(clone, manager);
 				isValid(clone);
 				logger.error("Database unhappy", e);

--- a/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
+++ b/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
@@ -27,6 +27,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Resource;
 import jakarta.ejb.EJB;
 import jakarta.ejb.Stateless;
 import jakarta.ejb.TransactionManagement;
@@ -45,6 +46,7 @@ import jakarta.json.JsonValue.ValueType;
 import jakarta.json.stream.JsonGenerator;
 import jakarta.persistence.EntityExistsException;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.Query;
 import jakarta.persistence.TypedQuery;
 import jakarta.transaction.HeuristicMixedException;
@@ -141,6 +143,12 @@ public class EntityBeanManager {
 	@EJB
 	SearchManager searchManager;
 
+	@Resource
+	UserTransaction userTransaction;
+
+	@PersistenceContext(unitName = "icat")
+	EntityManager entityManager;
+
 	private boolean log;
 
 	Marker fatal = MarkerFactory.getMarker("FATAL");
@@ -231,8 +239,7 @@ public class EntityBeanManager {
 		return false;
 	}
 
-	public CreateResponse create(String userId, EntityBaseBean bean, EntityManager manager,
-			UserTransaction userTransaction, boolean allAttributes, String ip) throws IcatException {
+	public CreateResponse create(String userId, EntityBaseBean bean, boolean allAttributes, String ip) throws IcatException {
 
 		logger.info(userId + " creating " + bean.getClass().getSimpleName());
 		try {
@@ -245,11 +252,11 @@ public class EntityBeanManager {
 			}
 			try {
 				long startMillis = log ? System.currentTimeMillis() : 0;
-				bean.preparePersist(userId, manager, persistMode);
+				bean.preparePersist(userId, entityManager, persistMode);
 				logger.trace(bean + " prepared for persist.");
-				manager.persist(bean);
+				entityManager.persist(bean);
 				logger.trace(bean + " persisted.");
-				manager.flush();
+				entityManager.flush();
 				logger.trace(bean + " flushed.");
 				// Check authz now everything persisted
 				gateKeeper.performAuthorisation(userId, bean, AccessType.CREATE);
@@ -258,7 +265,7 @@ public class EntityBeanManager {
 				long beanId = bean.getId();
 
 				if (searchActive) {
-					bean.addToSearch(manager, searchManager);
+					bean.addToSearch(entityManager, searchManager);
 				}
 				userTransaction.commit();
 				if (logRequests.contains(CallType.WRITE)) {
@@ -284,8 +291,8 @@ public class EntityBeanManager {
 						+ e.getMessage());
 				updateCache();
 
-				bean.preparePersist(userId, manager, persistMode);
-				isUnique(bean, manager);
+				bean.preparePersist(userId, entityManager, persistMode);
+				isUnique(bean);
 				isValid(bean);
 				throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
 						"Unexpected DB response " + e.getClass() + " " + e.getMessage());
@@ -302,17 +309,16 @@ public class EntityBeanManager {
 
 	}
 
-	private boolean createAllowed(String userId, EntityBaseBean bean, EntityManager manager,
-			UserTransaction userTransaction) throws IcatException {
+	private boolean createAllowed(String userId, EntityBaseBean bean) throws IcatException {
 		try {
 			userTransaction.begin();
 			try {
 				try {
-					bean.preparePersist(userId, manager, PersistMode.IMPORT_OR_WS);
+					bean.preparePersist(userId, entityManager, PersistMode.IMPORT_OR_WS);
 					logger.debug(bean + " prepared for persist (createAllowed).");
-					manager.persist(bean);
+					entityManager.persist(bean);
 					logger.debug(bean + " persisted (createAllowed).");
-					manager.flush();
+					entityManager.flush();
 					logger.debug(bean + " flushed (createAllowed).");
 				} catch (EntityExistsException e) {
 					throw new IcatException(IcatException.IcatExceptionType.OBJECT_ALREADY_EXISTS, e.getMessage());
@@ -320,8 +326,8 @@ public class EntityBeanManager {
 					userTransaction.rollback();
 					logger.debug("Transaction rolled back for creation of " + bean + " because of " + e.getClass() + " "
 							+ e.getMessage());
-					bean.preparePersist(userId, manager, PersistMode.IMPORT_OR_WS);
-					isUnique(bean, manager);
+					bean.preparePersist(userId, entityManager, PersistMode.IMPORT_OR_WS);
+					isUnique(bean);
 					isValid(bean);
 					throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
 							"Unexpected DB response " + e.getClass() + " " + e.getMessage());
@@ -354,19 +360,18 @@ public class EntityBeanManager {
 
 	}
 
-	public List<CreateResponse> createMany(String userId, List<EntityBaseBean> beans, EntityManager manager,
-			UserTransaction userTransaction, String ip) throws IcatException {
+	public List<CreateResponse> createMany(String userId, List<EntityBaseBean> beans, String ip) throws IcatException {
 		try {
 			userTransaction.begin();
 			List<CreateResponse> crs = new ArrayList<CreateResponse>();
 			try {
 				long startMillis = log ? System.currentTimeMillis() : 0;
 				for (EntityBaseBean bean : beans) {
-					bean.preparePersist(userId, manager, PersistMode.IMPORT_OR_WS);
+					bean.preparePersist(userId, entityManager, PersistMode.IMPORT_OR_WS);
 					logger.trace(bean + " prepared for persist.");
-					manager.persist(bean);
+					entityManager.persist(bean);
 					logger.trace(bean + " persisted.");
-					manager.flush();
+					entityManager.flush();
 					logger.trace(bean + " flushed.");
 					// Check authz now everything persisted
 					gateKeeper.performAuthorisation(userId, bean, AccessType.CREATE);
@@ -389,7 +394,7 @@ public class EntityBeanManager {
 
 				if (searchActive) {
 					for (EntityBaseBean bean : beans) {
-						bean.addToSearch(manager, searchManager);
+						bean.addToSearch(entityManager, searchManager);
 					}
 				}
 
@@ -409,8 +414,8 @@ public class EntityBeanManager {
 				int pos = crs.size();
 				EntityBaseBean bean = beans.get(pos);
 				try {
-					bean.preparePersist(userId, manager, PersistMode.IMPORT_OR_WS);
-					isUnique(bean, manager);
+					bean.preparePersist(userId, entityManager, PersistMode.IMPORT_OR_WS);
+					isUnique(bean);
 					isValid(bean);
 				} catch (IcatException e1) {
 					e1.setOffset(pos);
@@ -468,8 +473,7 @@ public class EntityBeanManager {
 		}
 	}
 
-	public void delete(String userId, List<EntityBaseBean> beans, EntityManager manager,
-			UserTransaction userTransaction, String ip) throws IcatException {
+	public void delete(String userId, List<EntityBaseBean> beans, String ip) throws IcatException {
 		if (beans == null) { // Wildlfy 10 receives null instead of empty list
 			beans = Collections.emptyList();
 		}
@@ -487,7 +491,7 @@ public class EntityBeanManager {
 				Set<EntityBaseBean> allBeansToDelete = new HashSet<>();
 				for (EntityBaseBean bean : beans) {
 					List<EntityBaseBean> beansToDelete = new ArrayList<>();
-					EntityBaseBean beanManaged = find(bean, manager);
+					EntityBaseBean beanManaged = find(bean);
 					beansToDelete.add(beanManaged);
 					beansToDelete.addAll(getDependentBeans(beanManaged));
 
@@ -497,8 +501,8 @@ public class EntityBeanManager {
 					for (EntityBaseBean b : beansToDelete) {
 						gateKeeper.performAuthorisation(userId, b, AccessType.DELETE);
 					}
-					manager.remove(beanManaged);
-					manager.flush();
+					entityManager.remove(beanManaged);
+					entityManager.flush();
 					logger.trace("Deleted bean " + bean + " flushed.");
 					allBeansToDelete.addAll(beansToDelete);
 					offset++;
@@ -543,8 +547,7 @@ public class EntityBeanManager {
 	 * Export all data
 	 */
 	@SuppressWarnings("serial")
-	public Response export(final String userId, final boolean allAttributes, final EntityManager manager,
-			UserTransaction userTransaction) {
+	public Response export(final String userId, final boolean allAttributes) {
 
 		logger.info(userId + " exporting complete schema");
 
@@ -567,7 +570,7 @@ public class EntityBeanManager {
 				output.write(("1.0" + linesep).getBytes());
 				for (String s : EntityInfoHandler.getExportEntityNames()) {
 					try {
-						exportTable(s, null, output, exportCaches, allAttributes, manager, userId);
+						exportTable(s, null, output, exportCaches, allAttributes, userId);
 					} catch (IOException e) {
 						throw e;
 					} catch (Exception e) {
@@ -590,12 +593,11 @@ public class EntityBeanManager {
 
 	/** export data described by the query */
 	@SuppressWarnings("serial")
-	public Response export(final String userId, String query, final boolean all, final EntityManager manager,
-			UserTransaction userTransaction) throws IcatException {
+	public Response export(final String userId, String query, final boolean all) throws IcatException {
 
 		logger.info(userId + " exporting " + query);
 
-		EntitySetResult esr = getEntitySet(userId, query, manager);
+		EntitySetResult esr = getEntitySet(userId, query);
 		List<?> result = esr.result;
 
 		if (result.size() > 0) {
@@ -636,7 +638,7 @@ public class EntityBeanManager {
 							Set<Long> table = ids.get(s);
 							if (!table.isEmpty()) {
 								try {
-									exportTable(s, table, output, exportCaches, all, manager, userId);
+									exportTable(s, table, output, exportCaches, all, userId);
 								} catch (IOException e) {
 									throw e;
 								} catch (Exception e) {
@@ -727,9 +729,8 @@ public class EntityBeanManager {
 	 * table
 	 */
 	private void exportTable(String beanName, Set<Long> ids, OutputStream output,
-			Map<String, Map<Long, String>> exportCaches, boolean allAttributes, EntityManager manager, String userId)
-			throws IcatException, IOException, IllegalAccessException, IllegalArgumentException,
-			InvocationTargetException {
+			Map<String, Map<Long, String>> exportCaches, boolean allAttributes, String userId) throws IcatException,
+			IOException, IllegalAccessException, IllegalArgumentException, InvocationTargetException {
 		logger.debug("Export " + (ids == null ? "complete" : "partial") + " " + beanName);
 		Class<? extends EntityBaseBean> klass = EntityInfoHandler.getClass(beanName);
 		output.write((linesep).getBytes());
@@ -752,7 +753,7 @@ public class EntityBeanManager {
 
 			while (true) {
 				/* Get beans in blocks. */
-				List<EntityBaseBean> beans = manager
+				List<EntityBaseBean> beans = entityManager
 						.createQuery("SELECT e from " + beanName + " e ORDER BY e.id", EntityBaseBean.class)
 						.setFirstResult(start).setMaxResults(500).getResultList();
 
@@ -776,7 +777,7 @@ public class EntityBeanManager {
 			}
 		} else {
 			for (Long id : ids) {
-				EntityBaseBean bean = manager.find(klass, id);
+				EntityBaseBean bean = entityManager.find(klass, id);
 				if (bean != null) {
 					exportBean(bean, output, qcolumn, allAttributes, fields, updaters, exportCaches, getters, fieldMap,
 							atts);
@@ -799,7 +800,6 @@ public class EntityBeanManager {
 	 * @param maxCount        The maximum size of acceptedResults. Once reached, no
 	 *                        more entries from newResults will be added.
 	 * @param userId          The user attempting to read the newResults.
-	 * @param manager         The EntityManager to use.
 	 * @param klass           The Class of the EntityBaseBean that is being
 	 *                        filtered.
 	 * @throws IcatException If more entities than the configuration option
@@ -807,8 +807,7 @@ public class EntityBeanManager {
 	 *                       IcatException is thrown instead.
 	 */
 	private ScoredEntityBaseBean filterReadAccess(List<ScoredEntityBaseBean> acceptedResults, List<ScoredEntityBaseBean> newResults,
-			int maxCount, String userId, EntityManager manager, Class<? extends EntityBaseBean> klass)
-			throws IcatException {
+			int maxCount, String userId, Class<? extends EntityBaseBean> klass) throws IcatException {
 
 		logger.debug("Got " + newResults.size() + " results from search engine");
 		Set<Long> allowedIds = gateKeeper.getReadableIds(userId, newResults, klass.getSimpleName());
@@ -845,7 +844,7 @@ public class EntityBeanManager {
 		return null;
 	}
 
-	private EntityBaseBean find(EntityBaseBean bean, EntityManager manager) throws IcatException {
+	private EntityBaseBean find(EntityBaseBean bean) throws IcatException {
 		Long primaryKey = bean.getId();
 		Class<? extends EntityBaseBean> entityClass = bean.getClass();
 		if (primaryKey == null) {
@@ -854,7 +853,7 @@ public class EntityBeanManager {
 		}
 		EntityBaseBean object = null;
 		try {
-			object = manager.find(entityClass, primaryKey);
+			object = entityManager.find(entityClass, primaryKey);
 		} catch (Throwable e) {
 			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "Unexpected DB response " + e);
 		}
@@ -866,8 +865,7 @@ public class EntityBeanManager {
 		return object;
 	}
 
-	public EntityBaseBean get(String userId, String query, long primaryKey, EntityManager manager, String ip)
-			throws IcatException {
+	public EntityBaseBean get(String userId, String query, long primaryKey, String ip) throws IcatException {
 
 		long startMillis = log ? System.currentTimeMillis() : 0;
 		logger.debug(userId + " issues get for " + query);
@@ -895,7 +893,7 @@ public class EntityBeanManager {
 
 		EntityBaseBean result;
 
-		EntityBaseBean beanManaged = manager.find(entityClass, primaryKey);
+		EntityBaseBean beanManaged = entityManager.find(entityClass, primaryKey);
 		if (beanManaged == null) {
 			throw new IcatException(IcatException.IcatExceptionType.NO_SUCH_OBJECT_FOUND,
 					entityClass.getSimpleName() + "[id:" + primaryKey + "] not found.");
@@ -956,7 +954,7 @@ public class EntityBeanManager {
 	}
 
 	@SuppressWarnings("unchecked")
-	private EntitySetResult getEntitySet(String userId, String query, EntityManager manager) throws IcatException {
+	private EntitySetResult getEntitySet(String userId, String query) throws IcatException {
 
 		if (query == null) {
 			throw new IcatException(IcatException.IcatExceptionType.BAD_PARAMETER, "query may not be null");
@@ -992,7 +990,7 @@ public class EntityBeanManager {
 		}
 
 		/* Get the JPQL which includes authz restrictions */
-		String jpql = q.getJPQL(userId, manager);
+		String jpql = q.getJPQL(userId, entityManager);
 		logger.info("Final search JPQL: " + jpql);
 
 		/* Null query indicates that nothing accepted by authz */
@@ -1003,7 +1001,7 @@ public class EntityBeanManager {
 		/* Create query - which may go wrong */
 		Query jpqlQuery;
 		try {
-			jpqlQuery = manager.createQuery(jpql);
+			jpqlQuery = entityManager.createQuery(jpql);
 		} catch (IllegalArgumentException e) {
 			/*
 			 * Parse the original query but without trailing LIMIT and INCLUDE
@@ -1022,7 +1020,7 @@ public class EntityBeanManager {
 					sb.append(token.getValue());
 					token = input.consume();
 				}
-				JpqlChecker.checkJPQL(sb.toString(), manager);
+				JpqlChecker.checkJPQL(sb.toString(), entityManager);
 
 			} catch (ParserException e1) {
 				throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
@@ -1085,7 +1083,7 @@ public class EntityBeanManager {
 					logger.debug("Type query for BigDecimal: " + typeQueryString);
 					Class<? extends Object> klass = null;
 					try {
-						Query typeQuery = manager.createQuery(typeQueryString).setMaxResults(1);
+						Query typeQuery = entityManager.createQuery(typeQueryString).setMaxResults(1);
 						klass = typeQuery.getSingleResult().getClass();
 					} catch (Exception e) {
 						throw new IcatException(IcatException.IcatExceptionType.BAD_PARAMETER,
@@ -1110,9 +1108,9 @@ public class EntityBeanManager {
 		return propertyHandler.props();
 	}
 
-	public double getRemainingMinutes(String sessionId, EntityManager manager) throws IcatException {
+	public double getRemainingMinutes(String sessionId) throws IcatException {
 		logger.debug("getRemainingMinutes for sessionId " + sessionId);
-		Session session = getSession(sessionId, manager);
+		Session session = getSession(sessionId);
 		return session.getRemainingMinutes();
 	}
 
@@ -1140,12 +1138,12 @@ public class EntityBeanManager {
 		}
 	}
 
-	private Session getSession(String sessionId, EntityManager manager) throws IcatException {
+	private Session getSession(String sessionId) throws IcatException {
 		Session session = null;
 		if (sessionId == null || sessionId.equals("")) {
 			throw new IcatException(IcatException.IcatExceptionType.SESSION, "Session Id cannot be null or empty.");
 		}
-		session = (Session) manager.find(Session.class, sessionId);
+		session = (Session) entityManager.find(Session.class, sessionId);
 		if (session == null) {
 			throw new IcatException(IcatException.IcatExceptionType.SESSION,
 					"Unable to find user by sessionid: " + sessionId);
@@ -1153,9 +1151,9 @@ public class EntityBeanManager {
 		return session;
 	}
 
-	public String getUserName(String sessionId, EntityManager manager) throws IcatException {
+	public String getUserName(String sessionId) throws IcatException {
 		try {
-			Session session = getSession(sessionId, manager);
+			Session session = getSession(sessionId);
 			String userName = session.getUserName();
 			logger.debug("user: " + userName + " is associated with: " + sessionId);
 			return userName;
@@ -1199,10 +1197,9 @@ public class EntityBeanManager {
 		key = propertyHandler.getKey();
 	}
 
-	public boolean isAccessAllowed(String userId, EntityBaseBean bean, EntityManager manager,
-			UserTransaction userTransaction, AccessType accessType) throws IcatException {
+	public boolean isAccessAllowed(String userId, EntityBaseBean bean, AccessType accessType) throws IcatException {
 		if (accessType == AccessType.CREATE) {
-			return createAllowed(userId, bean, manager, userTransaction);
+			return createAllowed(userId, bean);
 		} else {
 			try {
 				gateKeeper.performAuthorisation(userId, bean, accessType);
@@ -1216,15 +1213,14 @@ public class EntityBeanManager {
 		}
 	}
 
-	public boolean isLoggedIn(String userName, EntityManager manager) {
+	public boolean isLoggedIn(String userName) {
 		logger.debug("isLoggedIn for user " + userName);
-		return manager.createNamedQuery(Session.ISLOGGEDIN, Long.class).setParameter("userName", userName)
-				.getSingleResult() > 0;
+		return entityManager.createNamedQuery(Session.ISLOGGEDIN, Long.class).setParameter("userName", userName).getSingleResult() > 0;
 	}
 
-	private void isUnique(EntityBaseBean bean, EntityManager manager) throws IcatException {
+	private void isUnique(EntityBaseBean bean) throws IcatException {
 		logger.trace("Check uniqueness of {}", bean);
-		EntityBaseBean other = lookup(bean, manager);
+		EntityBaseBean other = lookup(bean);
 
 		if (other != null) {
 			Class<? extends EntityBaseBean> entityClass = bean.getClass();
@@ -1294,15 +1290,14 @@ public class EntityBeanManager {
 
 	}
 
-	public String login(String userName, int lifetimeMinutes, EntityManager manager, UserTransaction userTransaction,
-			String ip) throws IcatException {
+	public String login(String userName, int lifetimeMinutes, String ip) throws IcatException {
 		Session session = new Session(userName, lifetimeMinutes);
 		try {
 			userTransaction.begin();
 			try {
 				long startMillis = log ? System.currentTimeMillis() : 0;
-				manager.persist(session);
-				manager.flush();
+				entityManager.persist(session);
+				entityManager.flush();
 				userTransaction.commit();
 				String result = session.getId();
 				logger.debug("Session " + result + " persisted.");
@@ -1334,16 +1329,15 @@ public class EntityBeanManager {
 		}
 	}
 
-	public void logout(String sessionId, EntityManager manager, UserTransaction userTransaction, String ip)
-			throws IcatException {
+	public void logout(String sessionId, String ip) throws IcatException {
 		logger.debug("logout for sessionId " + sessionId);
 		try {
 			userTransaction.begin();
 			try {
 				long startMillis = log ? System.currentTimeMillis() : 0;
-				Session session = getSession(sessionId, manager);
-				manager.remove(session);
-				manager.flush();
+				Session session = getSession(sessionId);
+				entityManager.remove(session);
+				entityManager.flush();
 				userTransaction.commit();
 				logger.debug("Session {} removed.", session.getId());
 				if (logRequests.contains(CallType.SESSION)) {
@@ -1379,7 +1373,7 @@ public class EntityBeanManager {
 		}
 	}
 
-	public EntityBaseBean lookup(EntityBaseBean bean, EntityManager manager) throws IcatException {
+	public EntityBaseBean lookup(EntityBaseBean bean) throws IcatException {
 		Class<? extends EntityBaseBean> entityClass = bean.getClass();
 
 		Map<Field, Method> getters = EntityInfoHandler.getGetters(entityClass);
@@ -1397,7 +1391,7 @@ public class EntityBeanManager {
 			String name = f.getName();
 			queryString.append("o." + name + " = :" + name);
 		}
-		TypedQuery<EntityBaseBean> query = manager.createQuery(queryString.toString() + ")", EntityBaseBean.class);
+		TypedQuery<EntityBaseBean> query = entityManager.createQuery(queryString.toString() + ")", EntityBaseBean.class);
 		for (Field f : constraint) {
 			Object value;
 			try {
@@ -1440,19 +1434,17 @@ public class EntityBeanManager {
 	 *                 a batch from the search engine has more than this many
 	 *                 authorised results, then the excess results will be
 	 *                 discarded.
-	 * @param manager  EntityManager for finding entities from their Id.
 	 * @param ip       Used for logging only.
 	 * @param klass    Class of the entity to search.
 	 * @return SearchResult for the query.
 	 * @throws IcatException
 	 */
 	public List<ScoredEntityBaseBean> freeTextSearch(String userName, JsonObject jo, int maxCount,
-			EntityManager manager, String ip, Class<? extends EntityBaseBean> klass) throws IcatException {
+			String ip, Class<? extends EntityBaseBean> klass) throws IcatException {
 		long startMillis = System.currentTimeMillis();
 		List<ScoredEntityBaseBean> results = new ArrayList<>();
 		if (searchActive) {
-			searchDocuments(userName, jo, null, maxCount, maxCount, null, manager, klass,
-					startMillis, results, Arrays.asList("id"));
+			searchDocuments(userName, jo, null, maxCount, maxCount, null, klass, startMillis, results, Arrays.asList("id"));
 		}
 		logSearch(userName, ip, startMillis, results, "freeTextSearch");
 		return results;
@@ -1474,23 +1466,20 @@ public class EntityBeanManager {
 	 *                    authorised results, then the excess results will be
 	 *                    discarded.
 	 * @param sort        String of Json representing sort criteria.
-	 * @param manager     EntityManager for finding entities from their Id.
 	 * @param ip          Used for logging only.
 	 * @param klass       Class of the entity to search.
 	 * @return SearchResult for the query.
 	 * @throws IcatException
 	 */
 	public SearchResult freeTextSearchDocs(String userName, JsonObject jo, JsonValue searchAfter, int minCount,
-			int maxCount, String sort, EntityManager manager, String ip, Class<? extends EntityBaseBean> klass)
-			throws IcatException {
+			int maxCount, String sort, String ip, Class<? extends EntityBaseBean> klass) throws IcatException {
 		long startMillis = System.currentTimeMillis();
 		JsonValue lastSearchAfter = null;
 		List<ScoredEntityBaseBean> results = new ArrayList<>();
 		List<FacetDimension> dimensions = new ArrayList<>();
 		if (searchActive) {
 			List<String> fields = searchManager.getPublicSearchFields(gateKeeper, klass.getSimpleName());
-			lastSearchAfter = searchDocuments(userName, jo, searchAfter, maxCount, minCount, sort, manager, klass,
-					startMillis, results, fields);
+			lastSearchAfter = searchDocuments(userName, jo, searchAfter, maxCount, minCount, sort, klass, startMillis, results, fields);
 
 			if (jo.containsKey("facets")) {
 				List<JsonObject> jsonFacets = jo.getJsonArray("facets").getValuesAs(JsonObject.class);
@@ -1549,7 +1538,6 @@ public class EntityBeanManager {
 	 *                    authorised results, then the excess results will be
 	 *                    discarded.
 	 * @param sort        String of Json representing sort criteria.
-	 * @param manager     EntityManager for finding entities from their Id.
 	 * @param klass       Class of the entity to search.
 	 * @param startMillis The start time of the search in milliseconds
 	 * @param results     List of results from the search. Authorised results will
@@ -1560,16 +1548,15 @@ public class EntityBeanManager {
 	 * @throws IcatException If the search exceeds the maximum allowed time.
 	 */
 	private JsonValue searchDocuments(String userName, JsonObject jo, JsonValue searchAfter, int maxCount, int minCount,
-			String sort, EntityManager manager, Class<? extends EntityBaseBean> klass, long startMillis,
-			List<ScoredEntityBaseBean> results, List<String> fields) throws IcatException {
+			String sort, Class<? extends EntityBaseBean> klass, long startMillis, List<ScoredEntityBaseBean> results,
+			List<String> fields) throws IcatException {
 		JsonValue lastSearchAfter;
 		try {
 			do {
 				SearchResult lastSearchResult = searchManager.freeTextSearch(jo, searchAfter, searchSearchBlockSize,
 						sort, fields);
 				List<ScoredEntityBaseBean> allResults = lastSearchResult.getResults();
-				ScoredEntityBaseBean lastBean = filterReadAccess(results, allResults, maxCount, userName, manager,
-						klass);
+				ScoredEntityBaseBean lastBean = filterReadAccess(results, allResults, maxCount, userName, klass);
 				if (lastBean == null) {
 					// Haven't stopped early, so use the Lucene provided searchAfter document
 					lastSearchAfter = lastSearchResult.getSearchAfter();
@@ -1774,8 +1761,7 @@ public class EntityBeanManager {
 		}
 	}
 
-	public void searchPopulate(String entityName, Long minId, Long maxId, boolean delete, EntityManager manager)
-			throws IcatException {
+	public void searchPopulate(String entityName, Long minId, Long maxId, boolean delete) throws IcatException {
 		if (searchActive) {
 			// Throws IcatException if entityName is not an ICAT entity
 			EntityInfoHandler.getClass(entityName);
@@ -1786,7 +1772,7 @@ public class EntityBeanManager {
 
 	// This code might be in EntityBaseBean however this would mean that it
 	// would be processed by JPA which gets confused by it.
-	private void merge(EntityBaseBean thisBean, Object fromBean, EntityManager manager) throws IcatException {
+	private void merge(EntityBaseBean thisBean, Object fromBean) throws IcatException {
 		Class<? extends EntityBaseBean> klass = thisBean.getClass();
 		Map<Field, Method> setters = EntityInfoHandler.getSettersForUpdate(klass);
 		Map<Field, Method> getters = EntityInfoHandler.getGetters(klass);
@@ -1800,7 +1786,7 @@ public class EntityBeanManager {
 					logger.debug("Needs special processing as " + value + " is a bean");
 					if (value != null) {
 						Object pk = ((EntityBaseBean) value).getId();
-						value = (EntityBaseBean) manager.find(field.getType(), pk);
+						value = (EntityBaseBean) entityManager.find(field.getType(), pk);
 						fieldAndMethod.getValue().invoke(thisBean, value);
 					} else {
 						fieldAndMethod.getValue().invoke(thisBean, (EntityBaseBean) null);
@@ -1817,8 +1803,8 @@ public class EntityBeanManager {
 	}
 
 	private void parseEntity(EntityBaseBean bean, JsonObject contents, Class<? extends EntityBaseBean> klass,
-			EntityManager manager, List<EntityBaseBean> creates, Map<EntityBaseBean, Boolean> localUpdates,
-			boolean create, String userId) throws IcatException {
+			List<EntityBaseBean> creates, Map<EntityBaseBean, Boolean> localUpdates, boolean create, String userId)
+			throws IcatException {
 		Map<String, Field> fieldsByName = EntityInfoHandler.getFieldsByName(klass);
 		Set<Field> updaters = EntityInfoHandler.getSettersForUpdate(klass).keySet();
 		Map<Field, Method> setters = EntityInfoHandler.getSetters(klass);
@@ -1888,8 +1874,7 @@ public class EntityBeanManager {
 						}
 					} else {
 						try {
-							arg = parseSubEntity((JsonObject) fValue, rels.get(fName), manager, creates, localUpdates,
-									userId);
+							arg = parseSubEntity((JsonObject) fValue, rels.get(fName), creates, localUpdates, userId);
 							/* This may be an illegal update */
 							if (relInKey.contains(field)) {
 								if (bean.getId() != ((EntityBaseBean) arg).getId()) {
@@ -1916,8 +1901,7 @@ public class EntityBeanManager {
 						@SuppressWarnings("unchecked")
 						List<EntityBaseBean> beans = (List<EntityBaseBean>) getters.get(fName).invoke(bean);
 						for (JsonValue aValue : (JsonArray) fValue) {
-							EntityBaseBean arg = parseSubEntity((JsonObject) aValue, rels.get(fName), manager, creates,
-									localUpdates, userId);
+							EntityBaseBean arg = parseSubEntity((JsonObject) aValue, rels.get(fName), creates, localUpdates, userId);
 							beans.add(arg);
 						}
 					} catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
@@ -1942,9 +1926,8 @@ public class EntityBeanManager {
 
 	}
 
-	private EntityBaseBean parseSubEntity(JsonObject contents, Relationship relationship, EntityManager manager,
-			List<EntityBaseBean> creates, Map<EntityBaseBean, Boolean> localUpdates, String userId)
-			throws IcatException {
+	private EntityBaseBean parseSubEntity(JsonObject contents, Relationship relationship, List<EntityBaseBean> creates,
+			Map<EntityBaseBean, Boolean> localUpdates, String userId) throws IcatException {
 		logger.debug("Parse entity {} from relationship {}", contents, relationship);
 		Class<? extends EntityBaseBean> klass = relationship.getDestinationBean();
 
@@ -1967,24 +1950,23 @@ public class EntityBeanManager {
 						"Many to one related objects should have the id value set: " + contents);
 			}
 			bean.setId(contents.getJsonNumber("id").longValueExact());
-			bean = find(bean, manager);
+			bean = find(bean);
 		}
 
-		parseEntity(bean, contents, klass, manager, creates, localUpdates, create, userId);
+		parseEntity(bean, contents, klass, creates, localUpdates, create, userId);
 		return bean;
 
 	}
 
-	public void refresh(String sessionId, int lifetimeMinutes, EntityManager manager, UserTransaction userTransaction,
-			String ip) throws IcatException {
+	public void refresh(String sessionId, int lifetimeMinutes, String ip) throws IcatException {
 		logger.debug("logout for sessionId " + sessionId);
 		try {
 			userTransaction.begin();
 			try {
 				long startMillis = log ? System.currentTimeMillis() : 0;
-				Session session = getSession(sessionId, manager);
+				Session session = getSession(sessionId);
 				session.refresh(lifetimeMinutes);
-				manager.flush();
+				entityManager.flush();
 				userTransaction.commit();
 				logger.debug("Session {} refreshed.", session.getId());
 				if (logRequests.contains(CallType.SESSION)) {
@@ -2018,12 +2000,12 @@ public class EntityBeanManager {
 		}
 	}
 
-	public List<?> search(String userId, String query, EntityManager manager, String ip) throws IcatException {
+	public List<?> search(String userId, String query, String ip) throws IcatException {
 
 		long startMillis = log ? System.currentTimeMillis() : 0;
 		logger.info(userId + " searching for " + query);
 
-		EntitySetResult esr = getEntitySet(userId, query, manager);
+		EntitySetResult esr = getEntitySet(userId, query);
 		List<?> result = esr.result;
 
 		if (result.size() > 0 && (result.get(0) == null || result.get(0) instanceof EntityBaseBean)) {
@@ -2085,13 +2067,12 @@ public class EntityBeanManager {
 		}
 	}
 
-	public NotificationMessage update(String userId, EntityBaseBean bean, EntityManager manager,
-			UserTransaction userTransaction, boolean allAttributes, String ip) throws IcatException {
+	public NotificationMessage update(String userId, EntityBaseBean bean, boolean allAttributes, String ip) throws IcatException {
 		try {
 			userTransaction.begin();
 			try {
 				long startMillis = log ? System.currentTimeMillis() : 0;
-				EntityBaseBean beanManaged = find(bean, manager);
+				EntityBaseBean beanManaged = find(bean);
 				gateKeeper.performAuthorisation(userId, beanManaged, AccessType.UPDATE);
 				boolean identityChange = checkIdentityChange(beanManaged, bean);
 				if (identityChange) {
@@ -2128,12 +2109,12 @@ public class EntityBeanManager {
 					beanManaged.setModId(userId);
 					beanManaged.setModTime(new Date());
 				}
-				merge(beanManaged, bean, manager);
+				merge(beanManaged, bean);
 				if (identityChange) {
 					gateKeeper.performAuthorisation(userId, beanManaged, AccessType.CREATE);
 				}
-				beanManaged.postMergeFixup(manager);
-				manager.flush();
+				beanManaged.postMergeFixup(entityManager);
+				entityManager.flush();
 				logger.trace("Updated bean " + bean + " flushed.");
 				NotificationMessage notification = new NotificationMessage(Operation.U, bean, notificationRequests);
 				userTransaction.commit();
@@ -2148,7 +2129,7 @@ public class EntityBeanManager {
 					transmitter.processMessage("update", ip, baos.toString(), startMillis);
 				}
 				if (searchActive) {
-					searchManager.updateDocument(manager, beanManaged);
+					searchManager.updateDocument(entityManager, beanManaged);
 				}
 				return notification;
 			} catch (IcatException e) {
@@ -2157,10 +2138,10 @@ public class EntityBeanManager {
 			} catch (Throwable e) {
 				userTransaction.rollback();
 				updateCache();
-				EntityBaseBean beanManaged = find(bean, manager);
+				EntityBaseBean beanManaged = find(bean);
 				beanManaged.setModId(userId);
-				merge(beanManaged, bean, manager);
-				beanManaged.postMergeFixup(manager);
+				merge(beanManaged, bean);
+				beanManaged.postMergeFixup(entityManager);
 				isValid(beanManaged);
 				logger.error("Internal error", e);
 				throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
@@ -2181,8 +2162,7 @@ public class EntityBeanManager {
 		}
 	}
 
-	public List<Long> write(String userId, String json, EntityManager manager, UserTransaction userTransaction,
-			String ip) throws IcatException {
+	public List<Long> write(String userId, String json, String ip) throws IcatException {
 		logger.info("write called with {}", json);
 
 		if (json == null) {
@@ -2203,16 +2183,14 @@ public class EntityBeanManager {
 				if (top.getValueType() == ValueType.ARRAY) {
 
 					for (JsonValue obj : (JsonArray) top) {
-						EntityBaseBean bean = writeOne((JsonObject) obj, manager, userId, creates, updates,
-								userTransaction);
+						EntityBaseBean bean = writeOne((JsonObject) obj, userId, creates, updates);
 						if (bean != null) {
 							beanIds.add(bean.getId());
 						}
 						offset++;
 					}
 				} else {
-					EntityBaseBean bean = writeOne((JsonObject) top, manager, userId, creates, updates,
-							userTransaction);
+					EntityBaseBean bean = writeOne((JsonObject) top, userId, creates, updates);
 					if (bean != null) {
 						beanIds.add(bean.getId());
 					}
@@ -2248,10 +2226,10 @@ public class EntityBeanManager {
 
 				if (searchActive) {
 					for (EntityBaseBean eb : creates) {
-						searchManager.addDocument(manager, eb);
+						searchManager.addDocument(entityManager, eb);
 					}
 					for (EntityBaseBean eb : updates) {
-						searchManager.updateDocument(manager, eb);
+						searchManager.updateDocument(entityManager, eb);
 					}
 				}
 
@@ -2288,9 +2266,8 @@ public class EntityBeanManager {
 		}
 	}
 
-	private EntityBaseBean writeOne(JsonObject entity, EntityManager manager, String userId,
-			List<EntityBaseBean> creates, List<EntityBaseBean> updates, UserTransaction userTransaction)
-			throws IcatException {
+	private EntityBaseBean writeOne(JsonObject entity, String userId, List<EntityBaseBean> creates,
+			List<EntityBaseBean> updates) throws IcatException {
 		logger.debug("write one {}", entity);
 
 		if (entity.size() != 1) {
@@ -2322,11 +2299,11 @@ public class EntityBeanManager {
 				throw new IcatException(IcatExceptionType.BAD_PARAMETER,
 						"Badly formatted id: " + contents.getString("id"));
 			}
-			bean = find(bean, manager);
+			bean = find(bean);
 		}
 		List<EntityBaseBean> localCreates = new ArrayList<>();
 		Map<EntityBaseBean, Boolean> localUpdates = new HashMap<>();
-		parseEntity(bean, contents, klass, manager, localCreates, localUpdates, create, userId);
+		parseEntity(bean, contents, klass, localCreates, localUpdates, create, userId);
 
 		for (EntityBaseBean b : localUpdates.keySet()) {
 			b.setModId(userId);
@@ -2334,15 +2311,15 @@ public class EntityBeanManager {
 		}
 
 		try {
-			bean.preparePersist(userId, manager, PersistMode.REST);
+			bean.preparePersist(userId, entityManager, PersistMode.REST);
 			if (create) {
-				manager.persist(bean);
+				entityManager.persist(bean);
 				logger.trace(bean + " persisted.");
 			}
 			for (EntityBaseBean b : localUpdates.keySet()) {
-				b.postMergeFixup(manager);
+				b.postMergeFixup(entityManager);
 			}
-			manager.flush();
+			entityManager.flush();
 			logger.trace(bean + " flushed.");
 		} catch (Throwable e) {
 			/*
@@ -2359,11 +2336,11 @@ public class EntityBeanManager {
 			}
 			for (EntityBaseBean b : localCreates) {
 				isValid(b);
-				isUnique(b, manager);
+				isUnique(b);
 			}
 			for (EntityBaseBean b : localUpdates.keySet()) {
 				isValid(b);
-				isUnique(b, manager);
+				isUnique(b);
 			}
 
 			/*
@@ -2450,13 +2427,12 @@ public class EntityBeanManager {
 
 	}
 
-	public long cloneEntity(String userId, String beanName, long id, String keys, EntityManager manager,
-			UserTransaction userTransaction, String ip) throws IcatException {
+	public long cloneEntity(String userId, String beanName, long id, String keys, String ip) throws IcatException {
 		long startMillis = log ? System.currentTimeMillis() : 0;
 		logger.info("{} cloning {}/{}", userId, beanName, id);
 
 		Class<? extends EntityBaseBean> klass = EntityInfoHandler.getClass(beanName);
-		EntityBaseBean bean = manager.find(klass, id);
+		EntityBaseBean bean = entityManager.find(klass, id);
 		if (bean == null) {
 			throw new IcatException(IcatExceptionType.NO_SUCH_OBJECT_FOUND, beanName + ":" + id);
 		}
@@ -2481,7 +2457,7 @@ public class EntityBeanManager {
 				if (EntityBaseBean.class.isAssignableFrom(field.getType())) {
 					if (value != null) {
 						Object pk = ((EntityBaseBean) value).getId();
-						value = (EntityBaseBean) manager.find(field.getType(), pk);
+						value = (EntityBaseBean) entityManager.find(field.getType(), pk);
 						fieldAndMethod.getValue().invoke(clone, value);
 					}
 				} else {
@@ -2526,15 +2502,15 @@ public class EntityBeanManager {
 			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "" + e);
 		}
 
-		cloneOneToManys(bean, clone, klass, getters, setters, rs, manager, clonedTo, userId);
-		clone.preparePersist(userId, manager, PersistMode.CLONE);
+		cloneOneToManys(bean, clone, klass, getters, setters, rs, clonedTo, userId);
+		clone.preparePersist(userId, entityManager, PersistMode.CLONE);
 		logger.trace(clone + " prepared for persist.");
 
 		try {
 			try {
 				userTransaction.begin();
-				manager.persist(clone);
-				manager.flush();
+				entityManager.persist(clone);
+				entityManager.flush();
 				logger.trace(clone + " flushed.");
 
 				// Check authz now everything flushed
@@ -2569,8 +2545,8 @@ public class EntityBeanManager {
 				logger.trace("Transaction rolled back for creation of " + clone + " because of " + e.getClass() + " "
 						+ e.getMessage());
 				updateCache();
-				bean.preparePersist(userId, manager, PersistMode.CLONE);
-				isUnique(clone, manager);
+				bean.preparePersist(userId, entityManager, PersistMode.CLONE);
+				isUnique(clone);
 				isValid(clone);
 				logger.error("Database unhappy", e);
 				throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
@@ -2599,7 +2575,7 @@ public class EntityBeanManager {
 
 		if (searchActive) {
 			for (EntityBaseBean c : clonedTo.values()) {
-				searchManager.addDocument(manager, c);
+				searchManager.addDocument(entityManager, c);
 			}
 		}
 
@@ -2615,7 +2591,7 @@ public class EntityBeanManager {
 	}
 
 	private void cloneOneToManys(EntityBaseBean bean, EntityBaseBean clone, Class<? extends EntityBaseBean> klass,
-			Map<Field, Method> getters, Map<Field, Method> setters, Set<Relationship> rs, EntityManager manager,
+			Map<Field, Method> getters, Map<Field, Method> setters, Set<Relationship> rs,
 			Map<EntityBaseBean, EntityBaseBean> clonedTo, String userId) throws IcatException {
 
 		gateKeeper.performAuthorisation(userId, bean, AccessType.READ);
@@ -2670,8 +2646,7 @@ public class EntityBeanManager {
 									throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "" + e);
 								}
 							}
-							cloneOneToManys(c, subClone, subKlass, subGetters, subSetters, subRs, manager, clonedTo,
-									userId);
+							cloneOneToManys(c, subClone, subKlass, subGetters, subSetters, subRs, clonedTo, userId);
 						} else {
 							logger.trace("Setting back ref for existing clone {} {} {}", subClone, back, clone);
 							clonedCollection.add(subClone);

--- a/src/main/java/org/icatproject/core/manager/GateKeeper.java
+++ b/src/main/java/org/icatproject/core/manager/GateKeeper.java
@@ -25,6 +25,7 @@ import jakarta.jms.JMSException;
 import jakarta.json.JsonObject;
 import jakarta.json.JsonValue;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
 import jakarta.persistence.TypedQuery;
 
 import org.apache.http.client.methods.CloseableHttpResponse;
@@ -69,6 +70,9 @@ public class GateKeeper {
 
 	@EJB
 	GateKeeperHelper gateKeeperHelper;
+
+	@PersistenceContext(unitName = "icat")
+	EntityManager entityManager;
 
 	@EJB
 	PropertyHandler propertyHandler;
@@ -154,11 +158,10 @@ public class GateKeeper {
 	 * 
 	 * @param userId     The user making the READ request.
 	 * @param simpleName The name of the requested entity type.
-	 * @param manager    The EntityManager to use.
 	 * @return Returns a list of restrictions that apply to the requested entity
 	 *         type. If there are no restrictions, then returns null.
 	 */
-	private List<String> getRestrictions(String userId, String simpleName, EntityManager manager) {
+	private List<String> getRestrictions(String userId, String simpleName) {
 		if (rootUserNames.contains(userId)) {
 			logger.info("\"Root\" user " + userId + " is allowed READ to " + simpleName);
 			return null;
@@ -186,10 +189,9 @@ public class GateKeeper {
 	 * 
 	 * @param userId  The user making the READ request.
 	 * @param beans   The entities the user wants to READ.
-	 * @param manager The EntityManager to use.
 	 * @return A list of entities the user has read access to
 	 */
-	public List<EntityBaseBean> getReadable(String userId, List<EntityBaseBean> beans, EntityManager manager) {
+	public List<EntityBaseBean> getReadable(String userId, List<EntityBaseBean> beans) {
 
 		if (beans.size() == 0) {
 			return beans;
@@ -198,12 +200,12 @@ public class GateKeeper {
 		Class<? extends EntityBaseBean> objectClass = object.getClass();
 		String simpleName = objectClass.getSimpleName();
 
-		List<String> restrictions = getRestrictions(userId, simpleName, manager);
+		List<String> restrictions = getRestrictions(userId, simpleName);
 		if (restrictions == null) {
 			return beans;
 		}
 
-		Set<Long> readableIds = getReadableIds(userId, beans, restrictions, manager);
+		Set<Long> readableIds = getReadableIds(userId, beans, restrictions);
 
 		List<EntityBaseBean> results = new ArrayList<>();
 		for (EntityBaseBean bean : beans) {
@@ -223,23 +225,21 @@ public class GateKeeper {
 	 * @param userId     The user making the READ request.
 	 * @param entities   The entities to check.
 	 * @param simpleName The name of the requested entity type.
-	 * @param manager    The EntityManager to use.
 	 * @return Set of the ids that the user has read access to. If there are no
 	 *         restrictions, then returns null.
 	 */
-	public Set<Long> getReadableIds(String userId, List<? extends HasEntityId> entities, String simpleName,
-			EntityManager manager) {
+	public Set<Long> getReadableIds(String userId, List<? extends HasEntityId> entities, String simpleName) {
 
 		if (entities.size() == 0) {
 			return null;
 		}
 
-		List<String> restrictions = getRestrictions(userId, simpleName, manager);
+		List<String> restrictions = getRestrictions(userId, simpleName);
 		if (restrictions == null) {
 			return null;
 		}
 
-		return getReadableIds(userId, entities, restrictions, manager);
+		return getReadableIds(userId, entities, restrictions);
 	}
 
 	/**
@@ -248,11 +248,9 @@ public class GateKeeper {
 	 * @param userId       The user making the READ request.
 	 * @param entities     The entities to check.
 	 * @param restrictions The restrictions applying to the entities.
-	 * @param manager      The EntityManager to use.
 	 * @return Set of the ids that the user has read access to.
 	 */
-	private Set<Long> getReadableIds(String userId, List<? extends HasEntityId> entities, List<String> restrictions,
-			EntityManager manager) {
+	private Set<Long> getReadableIds(String userId, List<? extends HasEntityId> entities, List<String> restrictions) {
 
 		/*
 		 * IDs are processed in batches to avoid Oracle error: ORA-01795:
@@ -288,7 +286,7 @@ public class GateKeeper {
 		Set<Long> readableIds = new HashSet<>();
 		for (String idList : idLists) {
 			for (String qString : restrictions) {
-				TypedQuery<Long> q = manager.createQuery(qString.replace(":pkids", idList), Long.class);
+				TypedQuery<Long> q = entityManager.createQuery(qString.replace(":pkids", idList), Long.class);
 				if (qString.contains(":user")) {
 					q.setParameter("user", userId);
 				}
@@ -323,7 +321,7 @@ public class GateKeeper {
 	/**
 	 * Is the operation allowed
 	 */
-	public boolean isAccessAllowed(String user, EntityBaseBean object, AccessType access, EntityManager manager) {
+	public boolean isAccessAllowed(String user, EntityBaseBean object, AccessType access) {
 
 		Class<? extends EntityBaseBean> objectClass = object.getClass();
 		String simpleName = objectClass.getSimpleName();
@@ -374,7 +372,7 @@ public class GateKeeper {
 		Long keyVal = object.getId();
 
 		for (String qString : sortedQueries) {
-			TypedQuery<Long> q = manager.createQuery(qString, Long.class);
+			TypedQuery<Long> q = entityManager.createQuery(qString, Long.class);
 			if (qString.contains(":user")) {
 				q.setParameter("user", user);
 			}
@@ -406,18 +404,18 @@ public class GateKeeper {
 	 * 
 	 * @throws IcatException
 	 */
-	public void performAuthorisation(String user, EntityBaseBean object, AccessType access, EntityManager manager)
+	public void performAuthorisation(String user, EntityBaseBean object, AccessType access)
 			throws IcatException {
 
-		if (!isAccessAllowed(user, object, access, manager)) {
+		if (!isAccessAllowed(user, object, access)) {
 			throw new IcatException(IcatException.IcatExceptionType.INSUFFICIENT_PRIVILEGES,
 					access + " access to this " + object.getClass().getSimpleName() + " is not allowed.");
 		}
 	}
 
-	public void performUpdateAuthorisation(String user, EntityBaseBean bean, JsonObject contents, EntityManager manager)
+	public void performUpdateAuthorisation(String user, EntityBaseBean bean, JsonObject contents)
 			throws IcatException {
-		if (isAccessAllowed(user, bean, AccessType.UPDATE, manager)) {
+		if (isAccessAllowed(user, bean, AccessType.UPDATE)) {
 			return;
 		}
 
@@ -457,7 +455,7 @@ public class GateKeeper {
 						Long keyVal = bean.getId();
 
 						for (String qString : sortedQueries) {
-							TypedQuery<Long> q = manager.createQuery(qString, Long.class);
+							TypedQuery<Long> q = entityManager.createQuery(qString, Long.class);
 							if (qString.contains(":user")) {
 								q.setParameter("user", user);
 							}

--- a/src/main/java/org/icatproject/core/manager/NotificationMessage.java
+++ b/src/main/java/org/icatproject/core/manager/NotificationMessage.java
@@ -2,8 +2,6 @@ package org.icatproject.core.manager;
 
 import java.util.Map;
 
-import jakarta.persistence.EntityManager;
-
 import org.icatproject.core.IcatException;
 import org.icatproject.core.entity.EntityBaseBean;
 import org.icatproject.core.manager.PropertyHandler.Operation;
@@ -36,8 +34,7 @@ public class NotificationMessage {
 
 	private Message message;
 
-	public NotificationMessage(Operation operation, EntityBaseBean bean, EntityManager manager,
-			Map<String, NotificationRequest> notificationRequests) throws IcatException {
+	public NotificationMessage(Operation operation, EntityBaseBean bean, Map<String, NotificationRequest> notificationRequests) throws IcatException {
 		String entity = bean.getClass().getSimpleName();
 		String key = entity + ":" + operation.name();
 		NotificationRequest nr = notificationRequests.get(key);

--- a/src/main/java/org/icatproject/core/manager/SessionManager.java
+++ b/src/main/java/org/icatproject/core/manager/SessionManager.java
@@ -15,13 +15,13 @@ public class SessionManager {
 	private static final Logger logger = LoggerFactory.getLogger(SessionManager.class);
 
 	@PersistenceContext(unitName = "icat")
-	private EntityManager manager;
+	private EntityManager entityManager;
 
 	// Run every hour
 	@Schedule(hour = "*")
 	public void removeExpiredSessions() {
 		try {
-			int n = manager.createNamedQuery(Session.DELETE_EXPIRED).executeUpdate();
+			int n = entityManager.createNamedQuery(Session.DELETE_EXPIRED).executeUpdate();
 			logger.debug(n + " sessions were removed");
 		} catch (Throwable e) {
 			logger.error(e.getClass() + " " + e.getMessage());

--- a/src/main/java/org/icatproject/core/manager/search/LuceneApi.java
+++ b/src/main/java/org/icatproject/core/manager/search/LuceneApi.java
@@ -84,7 +84,7 @@ public class LuceneApi extends SearchApi {
 	}
 
 	@Override
-	public void addNow(String entityName, List<Long> ids, EntityManager manager,
+	public void addNow(String entityName, List<Long> ids, EntityManager entityManager,
 			Class<? extends EntityBaseBean> klass, ExecutorService getBeanDocExecutor)
 			throws IcatException, IOException, URISyntaxException {
 		URI uri = new URIBuilder(server).setPath(basePath + "/addNow/" + entityName).build();
@@ -97,10 +97,10 @@ public class LuceneApi extends SearchApi {
 				try (JsonGenerator gen = Json.createGenerator(beanDocs)) {
 					gen.writeStartArray();
 					for (Long id : ids) {
-						EntityBaseBean bean = (EntityBaseBean) manager.find(klass, id);
+						EntityBaseBean bean = (EntityBaseBean) entityManager.find(klass, id);
 						if (bean != null) {
 							gen.writeStartObject();
-							bean.getDoc(manager, gen);
+							bean.getDoc(entityManager, gen);
 							gen.writeEnd();
 						}
 					}
@@ -110,7 +110,7 @@ public class LuceneApi extends SearchApi {
 					logger.error("About to throw internal exception for ids {} because of", ids, e);
 					throw new IcatException(IcatExceptionType.INTERNAL, e.getMessage());
 				} finally {
-					manager.close();
+					entityManager.close();
 				}
 			});
 

--- a/src/main/java/org/icatproject/core/manager/search/OpensearchApi.java
+++ b/src/main/java/org/icatproject/core/manager/search/OpensearchApi.java
@@ -320,7 +320,7 @@ public class OpensearchApi extends SearchApi {
 	}
 
 	@Override
-	public void addNow(String entityName, List<Long> ids, EntityManager manager,
+	public void addNow(String entityName, List<Long> ids, EntityManager entityManager,
 			Class<? extends EntityBaseBean> klass, ExecutorService getBeanDocExecutor)
 			throws IcatException, IOException, URISyntaxException {
 		// getBeanDocExecutor is not used for this implementation, but is
@@ -329,12 +329,12 @@ public class OpensearchApi extends SearchApi {
 		try (JsonGenerator gen = Json.createGenerator(baos)) {
 			gen.writeStartArray();
 			for (long id : ids) {
-				EntityBaseBean bean = (EntityBaseBean) manager.find(klass, id);
+				EntityBaseBean bean = (EntityBaseBean) entityManager.find(klass, id);
 				if (bean != null) {
 					gen.writeStartObject().writeStartObject("create");
 					gen.write("_index", entityName).write("_id", bean.getId());
 					gen.writeStartObject("doc");
-					bean.getDoc(manager, gen);
+					bean.getDoc(entityManager, gen);
 					gen.writeEnd().writeEnd().writeEnd();
 				}
 			}

--- a/src/main/java/org/icatproject/core/manager/search/SearchApi.java
+++ b/src/main/java/org/icatproject/core/manager/search/SearchApi.java
@@ -320,7 +320,7 @@ public abstract class SearchApi {
 	 * 
 	 * @param entityName         The entity to create documents for.
 	 * @param ids                List of ids corresponding to the documents to add.
-	 * @param manager            EntityManager for finding the beans from their id.
+	 * @param entityManager      EntityManager for finding the beans from their id.
 	 * @param klass              Class of the entity to create documents for.
 	 * @param getBeanDocExecutor
 	 * @throws IcatException

--- a/src/main/java/org/icatproject/core/manager/search/SearchApi.java
+++ b/src/main/java/org/icatproject/core/manager/search/SearchApi.java
@@ -156,7 +156,7 @@ public abstract class SearchApi {
 	 *         <code>{`operation`: {"_index": `entityName`, "_id": `id`, "doc": {...}}}</code>
 	 * @throws IcatException
 	 */
-	public static String encodeOperation(EntityManager manager, String operation, EntityBaseBean bean) throws IcatException {
+	public static String encodeOperation(EntityManager entityManager, String operation, EntityBaseBean bean) throws IcatException {
 		Long icatId = bean.getId();
 		if (icatId == null) {
 			throw new IcatException(IcatExceptionType.BAD_PARAMETER, bean + " had null id");
@@ -167,7 +167,7 @@ public abstract class SearchApi {
 			gen.writeStartObject().writeStartObject(operation);
 			gen.write("_index", entityName).write("_id", icatId);
 			gen.writeStartObject("doc");
-			bean.getDoc(manager, gen);
+			bean.getDoc(entityManager, gen);
 			gen.writeEnd().writeEnd().writeEnd();
 		}
 		return baos.toString();
@@ -327,7 +327,7 @@ public abstract class SearchApi {
 	 * @throws IOException
 	 * @throws URISyntaxException
 	 */
-	public abstract void addNow(String entityName, List<Long> ids, EntityManager manager,
+	public abstract void addNow(String entityName, List<Long> ids, EntityManager entityManager,
 			Class<? extends EntityBaseBean> klass, ExecutorService getBeanDocExecutor)
 			throws IcatException, IOException, URISyntaxException;
 

--- a/src/main/java/org/icatproject/core/manager/search/SearchManager.java
+++ b/src/main/java/org/icatproject/core/manager/search/SearchManager.java
@@ -181,7 +181,7 @@ public class SearchManager {
 	public class IndexSome implements Callable<Long> {
 
 		private List<Long> ids;
-		private EntityManager manager;
+		private EntityManager entityManager;
 		private Class<? extends EntityBaseBean> klass;
 		private String entityName;
 		private long start;
@@ -194,7 +194,7 @@ public class SearchManager {
 				this.entityName = entityName;
 				klass = EntityInfoHandler.getClass(entityName);
 				this.ids = ids;
-				manager = entityManagerFactory.createEntityManager();
+				entityManager = entityManagerFactory.createEntityManager();
 				this.start = start;
 			} catch (Exception e) {
 				logger.error("About to throw internal exception because of", e);
@@ -205,7 +205,7 @@ public class SearchManager {
 		@Override
 		public Long call() throws Exception {
 			if (EntityInfoHandler.hasSearchDoc(klass)) {
-				searchApi.addNow(entityName, ids, manager, klass, getBeanDocExecutor);
+				searchApi.addNow(entityName, ids, entityManager, klass, getBeanDocExecutor);
 			}
 			return start;
 		}
@@ -392,12 +392,12 @@ public class SearchManager {
 
 	public class PopulateThread extends Thread {
 
-		private EntityManager manager;
+		private EntityManager entityManager;
 		private EntityManagerFactory entityManagerFactory;
 
 		public PopulateThread(EntityManagerFactory entityManagerFactory) {
 			this.entityManagerFactory = entityManagerFactory;
-			manager = entityManagerFactory.createEntityManager();
+			entityManager = entityManagerFactory.createEntityManager();
 			logger.info("Start new populate thread");
 		}
 
@@ -434,7 +434,7 @@ public class SearchManager {
 								query += " WHERE e.id > " + start;
 							}
 							query += " ORDER BY e.id";
-							List<Long> ids = manager
+							List<Long> ids = entityManager
 									.createQuery(query, Long.class)
 									.setMaxResults(populateBlockSize).getResultList();
 							if (ids.size() == 0) {
@@ -470,7 +470,7 @@ public class SearchManager {
 							tasks.add(start);
 							start = ids.get(ids.size() - 1);
 
-							manager.clear();
+							entityManager.clear();
 						}
 
 						/* Wait for the last few to finish */
@@ -496,7 +496,7 @@ public class SearchManager {
 				logger.error("Problem encountered in", t);
 				populateMap.remove(populatingClassEntry.getKey());
 			} finally {
-				manager.close();
+				entityManager.close();
 				popState = PopState.STOPPED;
 			}
 		}
@@ -580,10 +580,10 @@ public class SearchManager {
 		return requestedFields;
 	}
 
-	public void addDocument(EntityManager manager, EntityBaseBean bean) throws IcatException {
+	public void addDocument(EntityManager entityManager, EntityBaseBean bean) throws IcatException {
 		Class<? extends EntityBaseBean> klass = bean.getClass();
 		if (EntityInfoHandler.hasSearchDoc(klass) && entitiesToIndex.contains(klass.getSimpleName())) {
-			enqueue(SearchApi.encodeOperation(manager, "create", bean));
+			enqueue(SearchApi.encodeOperation(entityManager, "create", bean));
 			enqueueAggregation(bean);
 		}
 	}
@@ -931,10 +931,10 @@ public class SearchManager {
 		}
 	}
 
-	public void updateDocument(EntityManager manager, EntityBaseBean bean) throws IcatException {
+	public void updateDocument(EntityManager entityManager, EntityBaseBean bean) throws IcatException {
 		Class<? extends EntityBaseBean> klass = bean.getClass();
 		if (EntityInfoHandler.hasSearchDoc(klass) && entitiesToIndex.contains(klass.getSimpleName())) {
-			enqueue(SearchApi.encodeOperation(manager, "update", bean));
+			enqueue(SearchApi.encodeOperation(entityManager, "update", bean));
 			enqueueAggregation(bean);
 		}
 	}

--- a/src/main/java/org/icatproject/core/parser/SearchQuery.java
+++ b/src/main/java/org/icatproject/core/parser/SearchQuery.java
@@ -116,7 +116,7 @@ public class SearchQuery {
 		return sb.toString();
 	}
 
-	public String getJPQL(String userId, EntityManager manager) {
+	public String getJPQL(String userId, EntityManager entityManager) {
 		logger.debug("Processing: " + this);
 		logger.debug("=> fromClause: " + fromClause);
 		logger.debug("=> whereClause: " + whereClause);
@@ -150,7 +150,7 @@ public class SearchQuery {
 				logger.info("All are allowed READ to " + beanName);
 				restricted = false;
 			} else {
-				TypedQuery<Rule> query = manager.createNamedQuery(Rule.SEARCH_QUERY, Rule.class)
+				TypedQuery<Rule> query = entityManager.createNamedQuery(Rule.SEARCH_QUERY, Rule.class)
 						.setParameter("member", userId).setParameter("bean", beanName);
 				rules = query.getResultList();
 				SearchQuery.logger

--- a/src/main/java/org/icatproject/exposed/ICAT.java
+++ b/src/main/java/org/icatproject/exposed/ICAT.java
@@ -69,7 +69,6 @@ import org.icatproject.core.manager.CreateResponse;
 import org.icatproject.core.manager.EntityBeanManager;
 import org.icatproject.core.manager.EntityInfo;
 import org.icatproject.core.manager.EntityInfoHandler;
-import org.icatproject.core.manager.GateKeeper;
 import org.icatproject.core.manager.NotificationTransmitter;
 import org.icatproject.core.manager.PropertyHandler;
 import org.icatproject.core.manager.PropertyHandler.ExtendedAuthenticator;
@@ -87,9 +86,6 @@ public class ICAT {
 
 	@EJB
 	EntityBeanManager beanManager;
-
-	@EJB
-	GateKeeper gatekeeper;
 
 	private int lifetimeMinutes;
 
@@ -276,7 +272,7 @@ public class ICAT {
 	private void init() {
 		authPlugins = propertyHandler.getAuthPlugins();
 		lifetimeMinutes = propertyHandler.getLifetimeMinutes();
-		rootUserNames = gatekeeper.getRootUserNames();
+		rootUserNames = propertyHandler.getRootUserNames();
 	}
 
 	@WebMethod

--- a/src/main/java/org/icatproject/exposed/ICATRest.java
+++ b/src/main/java/org/icatproject/exposed/ICATRest.java
@@ -105,7 +105,7 @@ public class ICATRest {
 	private int lifetimeMinutes;
 
 	@PersistenceContext(unitName = "icat")
-	private EntityManager manager;
+	private EntityManager entityManager;
 
 	@EJB
 	Porter porter;
@@ -342,7 +342,7 @@ public class ICATRest {
 	@Path("port")
 	@Produces(MediaType.TEXT_PLAIN)
 	public Response exportData(@QueryParam("json") String jsonString) throws IcatException {
-		return porter.exportData(jsonString, manager);
+		return porter.exportData(jsonString, entityManager);
 	}
 
 	/**
@@ -377,7 +377,7 @@ public class ICATRest {
 		if (max != null) {
 			nMax = max;
 		}
-		List<Object> os = manager.createQuery(query, Object.class).setMaxResults(nMax).getResultList();
+		List<Object> os = entityManager.createQuery(query, Object.class).setMaxResults(nMax).getResultList();
 
 		StringBuilder sb = new StringBuilder();
 		if (os.size() == nMax) {
@@ -660,7 +660,7 @@ public class ICATRest {
 					if (name == null) {
 						name = part.getSubmittedFileName();
 					}
-					porter.importData(jsonString, stream, manager, request.getRemoteAddr());
+					porter.importData(jsonString, stream, entityManager, request.getRemoteAddr());
 				}
 			}
 		} catch (IOException e) {

--- a/src/main/java/org/icatproject/exposed/ICATRest.java
+++ b/src/main/java/org/icatproject/exposed/ICATRest.java
@@ -22,7 +22,6 @@ import java.util.Map.Entry;
 import java.util.Set;
 
 import jakarta.annotation.PostConstruct;
-import jakarta.annotation.Resource;
 import jakarta.ejb.EJB;
 import jakarta.ejb.Stateless;
 import jakarta.ejb.TransactionManagement;
@@ -48,7 +47,6 @@ import jakarta.persistence.PersistenceContext;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.Part;
-import jakarta.transaction.UserTransaction;
 import jakarta.ws.rs.Consumes;
 import jakarta.ws.rs.DELETE;
 import jakarta.ws.rs.FormParam;
@@ -115,9 +113,6 @@ public class ICATRest {
 	@EJB
 	PropertyHandler propertyHandler;
 
-	@Resource
-	private UserTransaction userTransaction;
-
 	private Set<String> rootUserNames;
 
 	private int maxEntities;
@@ -127,7 +122,7 @@ public class ICATRest {
 	private Map<String, String> cluster;
 
 	private void checkRoot(String sessionId) throws IcatException {
-		String userId = beanManager.getUserName(sessionId, manager);
+		String userId = beanManager.getUserName(sessionId);
 		if (!rootUserNames.contains(userId)) {
 			throw new IcatException(IcatExceptionType.INSUFFICIENT_PRIVILEGES, "user must be in rootUserNames");
 		}
@@ -174,9 +169,9 @@ public class ICATRest {
 	public String write(@Context HttpServletRequest request, @FormParam("sessionId") String sessionId,
 			@FormParam("entities") String json) throws IcatException {
 
-		String userName = beanManager.getUserName(sessionId, manager);
+		String userName = beanManager.getUserName(sessionId);
 
-		List<Long> beanIds = beanManager.write(userName, json, manager, userTransaction, request.getRemoteAddr());
+		List<Long> beanIds = beanManager.write(userName, json, request.getRemoteAddr());
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		try (JsonGenerator gen = Json.createGenerator(baos)) {
@@ -221,10 +216,9 @@ public class ICATRest {
 			@FormParam("name") String name, @FormParam("id") long id, @FormParam("keys") String keys)
 			throws IcatException {
 
-		String userName = beanManager.getUserName(sessionId, manager);
+		String userName = beanManager.getUserName(sessionId);
 
-		long beanId = beanManager.cloneEntity(userName, name, id, keys, manager, userTransaction,
-				request.getRemoteAddr());
+		long beanId = beanManager.cloneEntity(userName, name, id, keys, request.getRemoteAddr());
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		JsonGenerator gen = Json.createGenerator(baos);
@@ -273,8 +267,8 @@ public class ICATRest {
 		} catch (JsonException e) {
 			throw new IcatException(IcatExceptionType.BAD_PARAMETER, e.getMessage() + " in json " + json);
 		}
-		String userName = beanManager.getUserName(sessionId, manager);
-		beanManager.delete(userName, beans, manager, userTransaction, request.getRemoteAddr());
+		String userName = beanManager.getUserName(sessionId);
+		beanManager.delete(userName, beans, request.getRemoteAddr());
 	}
 
 	private EntityBaseBean getOne(JsonObject entity, int offset) throws IcatException {
@@ -348,7 +342,7 @@ public class ICATRest {
 	@Path("port")
 	@Produces(MediaType.TEXT_PLAIN)
 	public Response exportData(@QueryParam("json") String jsonString) throws IcatException {
-		return porter.exportData(jsonString, manager, userTransaction);
+		return porter.exportData(jsonString, manager);
 	}
 
 	/**
@@ -485,8 +479,8 @@ public class ICATRest {
 	@Produces(MediaType.APPLICATION_JSON)
 	public String getSession(@PathParam("sessionId") String sessionId) throws IcatException {
 
-		String userName = beanManager.getUserName(sessionId, manager);
-		double remainingMinutes = beanManager.getRemainingMinutes(sessionId, manager);
+		String userName = beanManager.getUserName(sessionId);
+		double remainingMinutes = beanManager.getRemainingMinutes(sessionId);
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		JsonGenerator gen = Json.createGenerator(baos);
@@ -513,7 +507,7 @@ public class ICATRest {
 	public String isLoggedIn1(@PathParam("userName") String userName) {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		try (JsonGenerator gen = Json.createGenerator(baos)) {
-			gen.writeStartObject().write("loggedIn", beanManager.isLoggedIn(userName, manager)).writeEnd();
+			gen.writeStartObject().write("loggedIn", beanManager.isLoggedIn(userName)).writeEnd();
 		}
 		return baos.toString();
 	}
@@ -567,7 +561,7 @@ public class ICATRest {
 	public String isLoggedIn2(@PathParam("mnemonic") String mnemonic, @PathParam("userName") String userName) {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		try (JsonGenerator gen = Json.createGenerator(baos)) {
-			gen.writeStartObject().write("loggedIn", beanManager.isLoggedIn(mnemonic + "/" + userName, manager))
+			gen.writeStartObject().write("loggedIn", beanManager.isLoggedIn(mnemonic + "/" + userName))
 					.writeEnd();
 		}
 		return baos.toString();
@@ -666,7 +660,7 @@ public class ICATRest {
 					if (name == null) {
 						name = part.getSubmittedFileName();
 					}
-					porter.importData(jsonString, stream, manager, userTransaction, request.getRemoteAddr());
+					porter.importData(jsonString, stream, manager, request.getRemoteAddr());
 				}
 			}
 		} catch (IOException e) {
@@ -882,8 +876,7 @@ public class ICATRest {
 		logger.debug("Using " + plugin + " to authenticate");
 
 		String userName = authenticator.authenticate(credentials, request.getRemoteAddr()).getUserName();
-		String sessionId = beanManager.login(userName, lifetimeMinutes, manager, userTransaction,
-				request.getRemoteAddr());
+		String sessionId = beanManager.login(userName, lifetimeMinutes, request.getRemoteAddr());
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		JsonGenerator gen = Json.createGenerator(baos);
@@ -909,7 +902,7 @@ public class ICATRest {
 	@Path("session/{sessionId}")
 	public void logout(@Context HttpServletRequest request, @PathParam("sessionId") String sessionId)
 			throws IcatException {
-		beanManager.logout(sessionId, manager, userTransaction, request.getRemoteAddr());
+		beanManager.logout(sessionId, request.getRemoteAddr());
 	}
 
 	/**
@@ -1026,7 +1019,7 @@ public class ICATRest {
 		if (query == null) {
 			throw new IcatException(IcatExceptionType.BAD_PARAMETER, "query is not set");
 		}
-		String userName = beanManager.getUserName(sessionId, manager);
+		String userName = beanManager.getUserName(sessionId);
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		try (JsonReader jr = Json.createReader(new ByteArrayInputStream(query.getBytes()))) {
 			JsonObject jo = jr.readObject();
@@ -1066,7 +1059,7 @@ public class ICATRest {
 				throw new IcatException(IcatExceptionType.BAD_PARAMETER, "target:" + target + " is not expected");
 			}
 			logger.debug("Free text search with query: {}", jo.toString());
-			objects = beanManager.freeTextSearch(userName, jo, maxCount, manager, request.getRemoteAddr(), klass);
+			objects = beanManager.freeTextSearch(userName, jo, maxCount, request.getRemoteAddr(), klass);
 			JsonGenerator gen = Json.createGenerator(baos);
 			gen.writeStartArray();
 			for (ScoredEntityBaseBean sb : objects) {
@@ -1220,7 +1213,7 @@ public class ICATRest {
 		if (maxCount == 0) {
 			maxCount = 100;
 		}
-		String userName = beanManager.getUserName(sessionId, manager);
+		String userName = beanManager.getUserName(sessionId);
 		JsonValue searchAfterValue = null;
 		if (searchAfter != null && searchAfter.length() > 0) {
 			try (JsonReader jr = Json.createReader(new StringReader(searchAfter))) {
@@ -1274,8 +1267,7 @@ public class ICATRest {
 				throw new IcatException(IcatExceptionType.BAD_PARAMETER, "target:" + target + " is not expected");
 			}
 
-			result = beanManager.freeTextSearchDocs(userName, jo, searchAfterValue, minCount, maxCount, sort,
-					manager, request.getRemoteAddr(), klass);
+			result = beanManager.freeTextSearchDocs(userName, jo, searchAfterValue, minCount, maxCount, sort, request.getRemoteAddr(), klass);
 
 			JsonGenerator gen = Json.createGenerator(baos);
 			gen.writeStartObject();
@@ -1546,7 +1538,7 @@ public class ICATRest {
 	public void lucenePopulate(@FormParam("sessionId") String sessionId, @PathParam("entityName") String entityName,
 			@PathParam("minid") long minid) throws IcatException {
 		checkRoot(sessionId);
-		beanManager.searchPopulate(entityName, minid, null, true, manager);
+		beanManager.searchPopulate(entityName, minid, null, true);
 	}
 
 	/**
@@ -1572,7 +1564,7 @@ public class ICATRest {
 			@FormParam("minId") Long minId, @FormParam("maxId") Long maxId, @FormParam("delete") boolean delete)
 			throws IcatException {
 		checkRoot(sessionId);
-		beanManager.searchPopulate(entityName, minId, maxId, delete, manager);
+		beanManager.searchPopulate(entityName, minId, maxId, delete);
 	}
 
 	/**
@@ -1591,7 +1583,7 @@ public class ICATRest {
 	@Path("session/{sessionId}")
 	public void refresh(@Context HttpServletRequest request, @PathParam("sessionId") String sessionId)
 			throws IcatException {
-		beanManager.refresh(sessionId, lifetimeMinutes, manager, userTransaction, request.getRemoteAddr());
+		beanManager.refresh(sessionId, lifetimeMinutes, request.getRemoteAddr());
 	}
 
 	/**
@@ -1642,10 +1634,10 @@ public class ICATRest {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		JsonGenerator gen = Json.createGenerator(baos);
 
-		String userName = beanManager.getUserName(sessionId, manager);
+		String userName = beanManager.getUserName(sessionId);
 		if (id == null) {
 			gen.writeStartArray();
-			for (Object result : beanManager.search(userName, query, manager, request.getRemoteAddr())) {
+			for (Object result : beanManager.search(userName, query, request.getRemoteAddr())) {
 				if (result == null) {
 					gen.writeNull();
 				} else if (result.getClass().isArray()) {
@@ -1662,7 +1654,7 @@ public class ICATRest {
 
 			gen.writeEnd();
 		} else {
-			EntityBaseBean result = beanManager.get(userName, query, id, manager, request.getRemoteAddr());
+			EntityBaseBean result = beanManager.get(userName, query, id, request.getRemoteAddr());
 			gen.writeStartObject();
 			gen.writeStartObject(result.getClass().getSimpleName());
 			jsonise(result, gen);

--- a/src/test/java/org/icatproject/core/manager/TestSearchApi.java
+++ b/src/test/java/org/icatproject/core/manager/TestSearchApi.java
@@ -98,7 +98,7 @@ public class TestSearchApi {
 	}
 
 	@PersistenceUnit(unitName = "icat")
-	private EntityManager manager;
+	private EntityManager entityManager;
 
 	private static final String SEARCH_AFTER_NOT_NULL = "Expected searchAfter to be set, but it was null";
 	private static final List<String> datafileFields = Arrays.asList("id", "name", "location", "datafileFormat.name",
@@ -544,9 +544,9 @@ public class TestSearchApi {
 		Parameter dateParameter = parameter(3 * i, new Date(now + 60000 * k * k), dateParameterType, parent);
 		Parameter numericParameter = parameter(3 * i + 1, new Double(j * j), numericParameterType, parent);
 		Parameter stringParameter = parameter(3 * i + 2, "v" + i * i, stringParameterType, parent);
-		queue.add(SearchApi.encodeOperation(manager, "create", dateParameter));
-		queue.add(SearchApi.encodeOperation(manager, "create", numericParameter));
-		queue.add(SearchApi.encodeOperation(manager, "create", stringParameter));
+		queue.add(SearchApi.encodeOperation(entityManager, "create", dateParameter));
+		queue.add(SearchApi.encodeOperation(entityManager, "create", numericParameter));
+		queue.add(SearchApi.encodeOperation(entityManager, "create", stringParameter));
 	}
 
 	/**
@@ -568,13 +568,13 @@ public class TestSearchApi {
 			Date startDate = new Date(now + investigationId * 60000);
 			Date endDate = new Date(now + (investigationId + 1) * 60000);
 			Investigation investigation = investigation(investigationId, word, startDate, endDate);
-			queue.add(SearchApi.encodeOperation(manager, "create", investigation));
+			queue.add(SearchApi.encodeOperation(entityManager, "create", investigation));
 
 			InvestigationFacilityCycle investigationFacilityCycle = new InvestigationFacilityCycle();
 			investigationFacilityCycle.setId(new Long(investigationId));
 			investigationFacilityCycle.setFacilityCycle(facilityCycle);
 			investigationFacilityCycle.setInvestigation(investigation);
-			queue.add(SearchApi.encodeOperation(manager, "create", investigationFacilityCycle));
+			queue.add(SearchApi.encodeOperation(entityManager, "create", investigationFacilityCycle));
 
 			InvestigationInstrument investigationInstrument = new InvestigationInstrument();
 			investigationInstrument.setId(new Long(investigationId));
@@ -584,7 +584,7 @@ public class TestSearchApi {
 				investigationInstrument.setInstrument(instrumentOne);
 			}
 			investigationInstrument.setInvestigation(investigation);
-			queue.add(SearchApi.encodeOperation(manager, "create", investigationInstrument));
+			queue.add(SearchApi.encodeOperation(entityManager, "create", investigationInstrument));
 
 			for (int userId = 0; userId < NUMUSERS; userId++) {
 				if (investigationId % (userId + 1) == 1) {
@@ -593,7 +593,7 @@ public class TestSearchApi {
 					String name = letters.substring(userId, userId + 1) + userId;
 					InvestigationUser investigationUser = investigationUser(investigationUserId, userId, name, fullName,
 							investigation);
-					queue.add(SearchApi.encodeOperation(manager, "create", investigationUser));
+					queue.add(SearchApi.encodeOperation(entityManager, "create", investigationUser));
 					investigationUserId++;
 				}
 			}
@@ -628,11 +628,11 @@ public class TestSearchApi {
 				if (datasetId < NUMSAMP) {
 					word = word("SType ", datasetId);
 					Sample sample = sample(datasetId, word, investigation);
-					queue.add(SearchApi.encodeOperation(manager, "create", sample));
+					queue.add(SearchApi.encodeOperation(entityManager, "create", sample));
 					dataset.setSample(sample);
 				}
 
-				queue.add(SearchApi.encodeOperation(manager, "create", dataset));
+				queue.add(SearchApi.encodeOperation(entityManager, "create", dataset));
 
 				if (datasetId % 3 == 1) {
 					populateParameters(queue, datasetId, dataset);
@@ -646,7 +646,7 @@ public class TestSearchApi {
 					word = word("DF", datafileId % 26);
 					Datafile datafile = datafile(datafileId, word, "/dir/" + word, new Date(now + datafileId * 60000),
 							dataset);
-					queue.add(SearchApi.encodeOperation(manager, "create", datafile));
+					queue.add(SearchApi.encodeOperation(entityManager, "create", datafile));
 
 					if (datafileId % 4 == 1) {
 						populateParameters(queue, datafileId, datafile);
@@ -672,7 +672,7 @@ public class TestSearchApi {
 		instrument.setId(instrumentId);
 		instrument.setName("bl" + instrumentId);
 		instrument.setFullName("Beamline " + instrumentId);
-		queue.add(SearchApi.encodeOperation(manager, "create", instrument));
+		queue.add(SearchApi.encodeOperation(entityManager, "create", instrument));
 		User user = new User();
 		user.setId(new Long(NUMUSERS) + instrumentId);
 		user.setName("scientist_" + instrumentId);
@@ -680,7 +680,7 @@ public class TestSearchApi {
 		instrumentScientist.setId(instrumentId);
 		instrumentScientist.setInstrument(instrument);
 		instrumentScientist.setUser(user);
-		queue.add(SearchApi.encodeOperation(manager, "create", instrumentScientist));
+		queue.add(SearchApi.encodeOperation(entityManager, "create", instrumentScientist));
 		return instrument;
 	}
 
@@ -698,7 +698,7 @@ public class TestSearchApi {
 		technique.setName("technique" + techniqueId);
 		technique.setDescription("Technique number " + techniqueId);
 		technique.setPid(Long.toString(techniqueId));
-		queue.add(SearchApi.encodeOperation(manager, "create", technique));
+		queue.add(SearchApi.encodeOperation(entityManager, "create", technique));
 		return technique;
 	}
 
@@ -715,7 +715,7 @@ public class TestSearchApi {
 		datasetTechnique.setId(technique.getId() * 100 + dataset.getId());
 		datasetTechnique.setTechnique(technique);
 		datasetTechnique.setDataset(dataset);
-		queue.add(SearchApi.encodeOperation(manager, "create", datasetTechnique));
+		queue.add(SearchApi.encodeOperation(entityManager, "create", datasetTechnique));
 	}
 
 	private String word(int j, int k, int l) {
@@ -1272,9 +1272,9 @@ public class TestSearchApi {
 		List<String> fields = Arrays.asList("id", "fileSize", "fileCount");
 
 		// Create
-		String createInvestigation = SearchApi.encodeOperation(manager, "create", investigation);
-		String createDataset = SearchApi.encodeOperation(manager, "create", dataset);
-		String createDatafile = SearchApi.encodeOperation(manager, "create", datafile);
+		String createInvestigation = SearchApi.encodeOperation(entityManager, "create", investigation);
+		String createDataset = SearchApi.encodeOperation(entityManager, "create", dataset);
+		String createDatafile = SearchApi.encodeOperation(entityManager, "create", datafile);
 		modify(createInvestigation, createDataset, createDatafile);
 		checkFileSize(datafileQuery, fields, 123, 1);
 		checkFileSize(datasetQuery, fields, 123, 1);
@@ -1282,13 +1282,13 @@ public class TestSearchApi {
 
 		// Update
 		datafile.setFileSize(456L);
-		modify(SearchApi.encodeOperation(manager, "update", datafile));
+		modify(SearchApi.encodeOperation(entityManager, "update", datafile));
 		checkFileSize(datafileQuery, fields, 456, 1);
 		checkFileSize(datasetQuery, fields, 456, 1);
 		checkFileSize(investigationQuery, fields, 456, 1);
 
 		// Delete
-		modify(SearchApi.encodeOperation(manager, "delete", datafile));
+		modify(SearchApi.encodeOperation(entityManager, "delete", datafile));
 		checkFileSize(datasetQuery, fields, 0, 0);
 		checkFileSize(investigationQuery, fields, 0, 0);
 	}
@@ -1333,7 +1333,7 @@ public class TestSearchApi {
 		FacetDimension pngFacet = new FacetDimension("", "datafileFormat.name", new FacetLabel("png", 1L));
 
 		// Original
-		modify(SearchApi.encodeOperation(manager, "create", elephantDatafile));
+		modify(SearchApi.encodeOperation(entityManager, "create", elephantDatafile));
 		checkResults(searchApi.getResults(elephantQuery, null, 5, null, datafileFields), 42L);
 		checkResults(searchApi.getResults(rhinoQuery, null, 5, null, datafileFields));
 		checkResults(searchApi.getResults(pdfQuery, null, 5, null, datafileFields));
@@ -1343,7 +1343,7 @@ public class TestSearchApi {
 		checkFacets(searchApi.facetSearch("Datafile", rangeFacetRequest, 5, 5), lowFacet);
 
 		// Change name and add a format
-		modify(SearchApi.encodeOperation(manager, "update", rhinoDatafile));
+		modify(SearchApi.encodeOperation(entityManager, "update", rhinoDatafile));
 		checkResults(searchApi.getResults(elephantQuery, null, 5, null, datafileFields));
 		checkResults(searchApi.getResults(rhinoQuery, null, 5, null, datafileFields), 42L);
 		checkResults(searchApi.getResults(pdfQuery, null, 5, null, datafileFields), 42L);
@@ -1353,7 +1353,7 @@ public class TestSearchApi {
 		checkFacets(searchApi.facetSearch("Datafile", rangeFacetRequest, 5, 5), highFacet);
 
 		// Change just the format
-		modify(SearchApi.encodeOperation(manager, "update", pngFormat));
+		modify(SearchApi.encodeOperation(entityManager, "update", pngFormat));
 		checkResults(searchApi.getResults(elephantQuery, null, 5, null, datafileFields));
 		checkResults(searchApi.getResults(rhinoQuery, null, 5, null, datafileFields), 42L);
 		checkResults(searchApi.getResults(pdfQuery, null, 5, null, datafileFields));
@@ -1363,7 +1363,7 @@ public class TestSearchApi {
 		checkFacets(searchApi.facetSearch("Datafile", rangeFacetRequest, 5, 5), highFacet);
 
 		// Remove the format
-		modify(SearchApi.encodeOperation(manager, "delete", pngFormat));
+		modify(SearchApi.encodeOperation(entityManager, "delete", pngFormat));
 		checkResults(searchApi.getResults(elephantQuery, null, 5, null, datafileFields));
 		checkResults(searchApi.getResults(rhinoQuery, null, 5, null, datafileFields), 42L);
 		checkResults(searchApi.getResults(pdfQuery, null, 5, null, datafileFields));
@@ -1380,8 +1380,8 @@ public class TestSearchApi {
 		checkResults(searchApi.getResults(pngQuery, 5));
 
 		// Multiple commands at once
-		modify(SearchApi.encodeOperation(manager, "create", elephantDatafile),
-				SearchApi.encodeOperation(manager, "update", rhinoDatafile),
+		modify(SearchApi.encodeOperation(entityManager, "create", elephantDatafile),
+				SearchApi.encodeOperation(entityManager, "update", rhinoDatafile),
 				SearchApi.encodeDeletion(elephantDatafile),
 				SearchApi.encodeDeletion(rhinoDatafile));
 		checkResults(searchApi.getResults(elephantQuery, 5));
@@ -1427,7 +1427,7 @@ public class TestSearchApi {
 		Parameter parameter = parameter(0, 273000, parameterType, investigation);
 
 		// Create with units of mK
-		modify(SearchApi.encodeOperation(manager, "create", investigation), SearchApi.encodeOperation(manager, "create", parameter));
+		modify(SearchApi.encodeOperation(entityManager, "create", investigation), SearchApi.encodeOperation(entityManager, "create", parameter));
 		// Assert the raw value is still 273000 (mK)
 		checkFacets(searchApi.facetSearch("InvestigationParameter", mKFacetQuery, 5, 5), rawExpectedFacet);
 		// Assert the SI value is 273 (K)
@@ -1435,7 +1435,7 @@ public class TestSearchApi {
 
 		// Change units only to "celsius"
 		parameterType.setUnits("celsius");
-		modify(SearchApi.encodeOperation(manager, "update", parameter));
+		modify(SearchApi.encodeOperation(entityManager, "update", parameter));
 		// Assert the raw value is still 273000 (deg C)
 		checkFacets(searchApi.facetSearch("InvestigationParameter", celsiusFacetQuery, 5, 5), rawExpectedFacet);
 		// Assert the SI value is 273273.15 (K)
@@ -1443,7 +1443,7 @@ public class TestSearchApi {
 
 		// Change units to something wrong
 		parameterType.setUnits("wrong");
-		modify(SearchApi.encodeOperation(manager, "update", parameterType));
+		modify(SearchApi.encodeOperation(entityManager, "update", parameterType));
 		// Assert the raw value is still 273000 (wrong)
 		checkFacets(searchApi.facetSearch("InvestigationParameter", wrongFacetQuery, 5, 5), rawExpectedFacet);
 		// Assert that the SI value has not been set due to conversion failing
@@ -1478,10 +1478,10 @@ public class TestSearchApi {
 		JsonObject rangeFilter = filterBuilder.build();
 
 		// Create
-		modify(SearchApi.encodeOperation(manager, "create", numericInvestigation),
-				SearchApi.encodeOperation(manager, "create", rangeInvestigation),
-				SearchApi.encodeOperation(manager, "create", numericParameter),
-				SearchApi.encodeOperation(manager, "create", rangeParameter));
+		modify(SearchApi.encodeOperation(entityManager, "create", numericInvestigation),
+				SearchApi.encodeOperation(entityManager, "create", rangeInvestigation),
+				SearchApi.encodeOperation(entityManager, "create", numericParameter),
+				SearchApi.encodeOperation(entityManager, "create", rangeParameter));
 
 		JsonObject query = buildQuery("Investigation", null, null, null, null, null, null,
 				new Filter("investigationparameter", numericFilter));
@@ -1538,12 +1538,12 @@ public class TestSearchApi {
 				new Filter("sampleparameter", filter));
 
 		// Create
-		modify(SearchApi.encodeOperation(manager, "create", investigation),
-				SearchApi.encodeOperation(manager, "create", dataset),
-				SearchApi.encodeOperation(manager, "create", datafile),
-				SearchApi.encodeOperation(manager, "create", sample),
-				SearchApi.encodeOperation(manager, "create", parameterType),
-				SearchApi.encodeOperation(manager, "create", parameter));
+		modify(SearchApi.encodeOperation(entityManager, "create", investigation),
+				SearchApi.encodeOperation(entityManager, "create", dataset),
+				SearchApi.encodeOperation(entityManager, "create", datafile),
+				SearchApi.encodeOperation(entityManager, "create", sample),
+				SearchApi.encodeOperation(entityManager, "create", parameterType),
+				SearchApi.encodeOperation(entityManager, "create", parameter));
 
 		// Test
 		checkFacets(searchApi.facetSearch("SampleParameter", sampleParameterFacetQuery, 5, 5), sampleParemeterFacet);


### PR DESCRIPTION
Avoid passing instances of `EntityManager` and `UserTransaction` between EJB methods. These are interfaces to the application container's transaction management system and don't in themselves represent a database transaction. Passing them between EJB methods is functionally the same as injecting them into both EJBs, but could lead to misunderstanding how they work. `EntityManager` still needs to be passed to some entity methods because it cannot be injected into an entity.

Remove EJBs from method signatures where they are not used.

Renames all instances of `EntityManager` to `entityManager` instead of  `manager` for greater clarity.
