### PR TITLE
Upgrade to JUnit 5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,9 +90,16 @@
 		</dependency>
 
 		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.13.2</version>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.13.1</version>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-migrationsupport</artifactId>
+			<version>5.13.1</version>
 			<scope>test</scope>
 		</dependency>
 
@@ -220,7 +227,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.18.1</version>
+				<version>3.5.3</version>
 				<configuration>
 					<workingDirectory>${basedir}/src/test/config</workingDirectory>
 					<excludes>
@@ -241,7 +248,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-failsafe-plugin</artifactId>
-				<version>2.18.1</version>
+				<version>3.5.3</version>
 				<configuration>
 					<includes>
 						<include>**/integration/Test*.java</include>

--- a/src/test/java/org/icatproject/core/manager/TestEntityInfo.java
+++ b/src/test/java/org/icatproject/core/manager/TestEntityInfo.java
@@ -1,9 +1,10 @@
 package org.icatproject.core.manager;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
@@ -33,13 +34,14 @@ import org.icatproject.core.entity.Rule;
 import org.icatproject.core.entity.User;
 import org.icatproject.core.entity.Study;
 import org.icatproject.core.manager.EntityInfoHandler.Relationship;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 public class TestEntityInfo {
 
-	@Test(expected = IcatException.class)
+	@Test
 	public void testBadname() throws Exception {
-		EntityInfoHandler.getEntityInfo("Fred");
+		assertThrows(IcatException.class, () -> EntityInfoHandler.getEntityInfo("Fred"));
 	}
 
 	@Test
@@ -215,14 +217,14 @@ public class TestEntityInfo {
 	private void testConstraint(Class<? extends EntityBaseBean> klass, String... name) throws Exception {
 		List<Field> result = EntityInfoHandler.getConstraintFields(klass);
 		if (name.length == 0) {
-			assertEquals("One", 0, result.size());
+			assertEquals(0, result.size(), "One");
 		} else {
-			assertFalse("One", 0 == result.size());
-			assertEquals(klass.getSimpleName() + " count", name.length, result.size());
+			assertFalse(0 == result.size(), "One");
+			assertEquals(name.length, result.size(), klass.getSimpleName() + " count");
 
 			int i = 0;
 			for (Field re : result) {
-				assertEquals(klass.getSimpleName() + " value " + i, name[i++], re.getName());
+				assertEquals(name[i++], re.getName(), klass.getSimpleName() + " value " + i);
 			}
 		}
 	}
@@ -292,16 +294,16 @@ public class TestEntityInfo {
 		for (Relationship rel : results) {
 			rStrings.add(rel.toString());
 		}
-		assertEquals(klass.getSimpleName() + " count", rels.length, results.size());
+		assertEquals(rels.length, results.size(), klass.getSimpleName() + " count");
 		for (String rel : rels) {
-			assertTrue(klass.getSimpleName() + " value " + rel, rStrings.contains(rel));
+			assertTrue(rStrings.contains(rel), klass.getSimpleName() + " value " + rel);
 		}
 		Set<Entry<String, Relationship>> map = EntityInfoHandler.getRelationshipsByName(klass).entrySet();
 		assertEquals(rels.length, map.size());
 		for (Entry<String, Relationship> e : map) {
 			Relationship rel = e.getValue();
 			assertEquals(rel.getField().getName(), e.getKey());
-			assertTrue(klass.getSimpleName() + " value " + rel, rStrings.contains(rel.toString()));
+			assertTrue(rStrings.contains(rel.toString()), klass.getSimpleName() + " value " + rel);
 		}
 	}
 
@@ -330,9 +332,9 @@ public class TestEntityInfo {
 			rStrings.add(rel.getDestinationBean().getSimpleName());
 		}
 		// System.out.println(results);
-		assertEquals(klass.getSimpleName() + " count", rels.length, results.size());
+		assertEquals(rels.length, results.size(), klass.getSimpleName() + " count");
 		for (String rel : rels) {
-			assertTrue(klass.getSimpleName() + " value " + rel, rStrings.contains(rel));
+			assertTrue(rStrings.contains(rel), klass.getSimpleName() + " value " + rel);
 		}
 	}
 
@@ -354,10 +356,10 @@ public class TestEntityInfo {
 		for (Field field : results) {
 			rStrings.add(field.getName());
 		}
-		assertEquals(klass.getSimpleName() + " count", nnfs.length, results.size());
+		assertEquals(nnfs.length, results.size(), klass.getSimpleName() + " count");
 
 		for (String nnf : nnfs) {
-			assertTrue(klass.getSimpleName() + " value " + nnf, rStrings.contains(nnf));
+			assertTrue(rStrings.contains(nnf), klass.getSimpleName() + " value " + nnf);
 		}
 	}
 
@@ -381,10 +383,10 @@ public class TestEntityInfo {
 		for (Entry<Field, Integer> entry : results.entrySet()) {
 			rStrings.add(entry.getKey().getName() + " " + entry.getValue());
 		}
-		assertEquals(klass.getSimpleName() + " count", sfs.length, results.size());
+		assertEquals(sfs.length, results.size(), klass.getSimpleName() + " count");
 
 		for (String sf : sfs) {
-			assertTrue(klass.getSimpleName() + " value " + sf, rStrings.contains(sf));
+			assertTrue(rStrings.contains(sf), klass.getSimpleName() + " value " + sf);
 		}
 	}
 
@@ -448,44 +450,44 @@ public class TestEntityInfo {
 		for (Field field : results) {
 			rStrings.add(field.getName());
 		}
-		assertEquals(klass.getSimpleName() + " count", fieldNames.length, results.size());
+		assertEquals(fieldNames.length, results.size(), klass.getSimpleName() + " count");
 
 		for (String fn : fieldNames) {
-			assertTrue(klass.getSimpleName() + " value " + fn, rStrings.contains(fn));
+			assertTrue(rStrings.contains(fn), klass.getSimpleName() + " value " + fn);
 		}
 	}
 
 	private void testGetters(Class<? extends EntityBaseBean> klass, int count) throws Exception {
 		Map<Field, Method> results = EntityInfoHandler.getGetters(klass);
-		assertEquals(klass.getSimpleName() + " count", count, results.size());
+		assertEquals(count, results.size(), klass.getSimpleName() + " count");
 		for (Entry<Field, Method> entry : results.entrySet()) {
 			String cap = entry.getKey().getName();
 			cap = Character.toUpperCase(cap.charAt(0)) + cap.substring(1);
 			String m = entry.getValue().getName();
-			assertTrue(klass.getSimpleName() + " value ", m.equals("get" + cap) || m.equals("is" + cap));
+			assertTrue(m.equals("get" + cap) || m.equals("is" + cap), klass.getSimpleName() + " value ");
 		}
 	}
 
 	private void testSettersForUpdate(Class<? extends EntityBaseBean> klass, int count) throws Exception {
 		Map<Field, Method> results = EntityInfoHandler.getSettersForUpdate(klass);
 
-		assertEquals(klass.getSimpleName() + " count", count, results.size());
+		assertEquals(count, results.size(), klass.getSimpleName() + " count");
 		for (Entry<Field, Method> entry : results.entrySet()) {
 			String cap = entry.getKey().getName();
 			cap = Character.toUpperCase(cap.charAt(0)) + cap.substring(1);
 			String m = entry.getValue().getName();
-			assertTrue(klass.getSimpleName() + " value ", m.equals("set" + cap));
+			assertTrue(m.equals("set" + cap), klass.getSimpleName() + " value ");
 		}
 	}
 
 	private void testSetters(Class<? extends EntityBaseBean> klass, int count) throws Exception {
 		Map<Field, Method> results = EntityInfoHandler.getSetters(klass);
-		assertEquals(klass.getSimpleName() + " count", count, results.size());
+		assertEquals(count, results.size(), klass.getSimpleName() + " count");
 		for (Entry<Field, Method> entry : results.entrySet()) {
 			String cap = entry.getKey().getName();
 			cap = Character.toUpperCase(cap.charAt(0)) + cap.substring(1);
 			String m = entry.getValue().getName();
-			assertTrue(klass.getSimpleName() + " value ", m.equals("set" + cap));
+			assertTrue(m.equals("set" + cap), klass.getSimpleName() + " value ");
 		}
 	}
 

--- a/src/test/java/org/icatproject/core/manager/TestSearchApi.java
+++ b/src/test/java/org/icatproject/core/manager/TestSearchApi.java
@@ -1,9 +1,9 @@
 package org.icatproject.core.manager;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Array;
 import java.net.URI;
@@ -59,15 +59,13 @@ import org.icatproject.core.manager.search.ParameterPOJO;
 import org.icatproject.core.manager.search.ScoredEntityBaseBean;
 import org.icatproject.core.manager.search.SearchApi;
 import org.icatproject.core.manager.search.SearchResult;
-import org.junit.Before;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
+
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@RunWith(Parameterized.class)
 public class TestSearchApi {
 
 	private class Filter {
@@ -125,7 +123,7 @@ public class TestSearchApi {
 
 	final static Logger logger = LoggerFactory.getLogger(TestSearchApi.class);
 
-	@Parameterized.Parameters
+	// Produces the parameter used in the ParameterizedTests
 	public static Iterable<SearchApi> data() throws URISyntaxException, IcatException {
 		String searchEngine = System.getProperty("searchEngine");
 		String searchUrls = System.getProperty("searchUrls");
@@ -143,7 +141,6 @@ public class TestSearchApi {
 		}
 	}
 
-	@Parameterized.Parameter
 	public SearchApi searchApi;
 
 	String letters = "abcdefghijklmnopqrstuvwxyz";
@@ -316,7 +313,7 @@ public class TestSearchApi {
 			List<FacetLabel> expectedLabels = expectedFacet.getFacets();
 			List<FacetLabel> actualLabels = actualFacet.getFacets();
 			String message = "Expected " + expectedLabels.toString() + " but got " + actualLabels.toString();
-			assertEquals(message, expectedLabels.size(), actualLabels.size());
+			assertEquals(expectedLabels.size(), actualLabels.size(), message);
 			for (int j = 0; j < expectedLabels.size(); j++) {
 				FacetLabel expectedLabel = expectedLabels.get(j);
 				FacetLabel actualLabel = actualLabels.get(j);
@@ -325,7 +322,7 @@ public class TestSearchApi {
 				long actualValue = actualLabel.getValue();
 				assertEquals(label, actualLabel.getLabel());
 				message = "Label <" + label + ">: ";
-				assertEquals(message, expectedValue, actualValue);
+				assertEquals(expectedValue, actualValue, message);
 			}
 		}
 	}
@@ -730,13 +727,11 @@ public class TestSearchApi {
 		return prefix + jString + jString + jString;
 	}
 
-	@Before
-	public void before() throws Exception {
+	@MethodSource("data")
+	@ParameterizedTest
+	public void datafiles(SearchApi searchApi) throws Exception {
+		this.searchApi = searchApi;
 		searchApi.clear();
-	}
-
-	@Test
-	public void datafiles() throws Exception {
 		populate();
 		JsonObjectBuilder sortBuilder = Json.createObjectBuilder();
 		String sort;
@@ -747,7 +742,7 @@ public class TestSearchApi {
 		JsonValue searchAfter = lsr.getSearchAfter();
 		checkResults(lsr, 0L, 1L, 2L, 3L, 4L);
 		checkDatafile(lsr.getResults().get(0));
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 
 		lsr = searchApi.getResults(query, searchAfter, 200, null, datafileFields);
 		assertNull(lsr.getSearchAfter());
@@ -758,46 +753,46 @@ public class TestSearchApi {
 		lsr = searchApi.getResults(query, null, 5, sort, datafileFields);
 		checkOrder(lsr, 0L, 1L, 2L, 3L, 4L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 		lsr = searchApi.getResults(query, searchAfter, 5, sort, datafileFields);
 		checkOrder(lsr, 5L, 6L, 7L, 8L, 9L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 
 		// Test searchAfter preserves the sorting of original search (desc)
 		sort = sortBuilder.add("date", "desc").build().toString();
 		lsr = searchApi.getResults(query, null, 5, sort, datafileFields);
 		checkOrder(lsr, 99L, 98L, 97L, 96L, 95L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 		lsr = searchApi.getResults(query, searchAfter, 5, sort, datafileFields);
 		checkOrder(lsr, 94L, 93L, 92L, 91L, 90L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 
 		// Test tie breaks on fields with identical values (asc)
 		sort = sortBuilder.add("name", "asc").build().toString();
 		lsr = searchApi.getResults(query, null, 5, sort, datafileFields);
 		checkOrder(lsr, 0L, 26L, 52L, 78L, 1L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 		sort = sortBuilder.add("name", "asc").add("date", "desc").build().toString();
 		lsr = searchApi.getResults(query, null, 5, sort, datafileFields);
 		checkOrder(lsr, 78L, 52L, 26L, 0L, 79L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 
 		// Test tie breaks on fields with identical values (desc)
 		sort = sortBuilder.add("name", "desc").build().toString();
 		lsr = searchApi.getResults(query, null, 5, sort, datafileFields);
 		checkOrder(lsr, 25L, 51L, 77L, 24L, 50L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 		sort = sortBuilder.add("name", "desc").add("date", "desc").build().toString();
 		lsr = searchApi.getResults(query, null, 5, sort, datafileFields);
 		checkOrder(lsr, 77L, 51L, 25L, 76L, 50L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 
 		query = buildQuery("Datafile", "e4", null, null, null, null, null);
 		lsr = searchApi.getResults(query, 100, null);
@@ -875,8 +870,11 @@ public class TestSearchApi {
 		checkResults(lsr, 13L, 65L);
 	}
 
-	@Test
-	public void datasets() throws Exception {
+	@MethodSource("data")
+	@ParameterizedTest
+	public void datasets(SearchApi searchApi) throws Exception {
+		this.searchApi = searchApi;
+		searchApi.clear();
 		populate();
 		JsonObjectBuilder sortBuilder = Json.createObjectBuilder();
 		String sort;
@@ -886,7 +884,7 @@ public class TestSearchApi {
 		checkResults(lsr, 0L, 1L, 2L, 3L, 4L);
 		checkDataset(lsr.getResults().get(0));
 		JsonValue searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 		lsr = searchApi.getResults(query, searchAfter, 100, null, datasetFields);
 		assertNull(lsr.getSearchAfter());
 		checkResults(lsr, 5L, 6L, 7L, 8L, 9L, 10L, 11L, 12L, 13L, 14L, 15L, 16L, 17L, 18L, 19L, 20L, 21L, 22L, 23L, 24L,
@@ -897,34 +895,34 @@ public class TestSearchApi {
 		lsr = searchApi.getResults(query, 5, sort);
 		checkOrder(lsr, 0L, 1L, 2L, 3L, 4L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 		lsr = searchApi.getResults(query, searchAfter, 5, sort, datasetFields);
 		checkOrder(lsr, 5L, 6L, 7L, 8L, 9L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 
 		// Test searchAfter preserves the sorting of original search (desc)
 		sort = sortBuilder.add("date", "desc").build().toString();
 		lsr = searchApi.getResults(query, 5, sort);
 		checkOrder(lsr, 29L, 28L, 27L, 26L, 25L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 		lsr = searchApi.getResults(query, searchAfter, 5, sort, datasetFields);
 		checkOrder(lsr, 24L, 23L, 22L, 21L, 20L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 
 		// Test tie breaks on fields with identical values (asc)
 		sort = sortBuilder.add("name", "asc").build().toString();
 		lsr = searchApi.getResults(query, null, 5, sort, datasetFields);
 		checkOrder(lsr, 0L, 26L, 1L, 27L, 2L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 		sort = sortBuilder.add("name", "asc").add("date", "desc").build().toString();
 		lsr = searchApi.getResults(query, 5, sort);
 		checkOrder(lsr, 26L, 0L, 27L, 1L, 28L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 
 		lsr = searchApi.getResults(buildQuery("Dataset", "e4", null, null, null, null, null), 100,
 				null);
@@ -1026,8 +1024,11 @@ public class TestSearchApi {
 		checkFacets(searchApi.facetSearch("InvestigationInstrument", instrumentFacetRequestOne, 5, 5), instrumentFacetOne);
 	}
 
-	@Test
-	public void investigations() throws Exception {
+	@MethodSource("data")
+	@ParameterizedTest
+	public void investigations(SearchApi searchApi) throws Exception {
+		this.searchApi = searchApi;
+		searchApi.clear();
 		populate();
 		JsonObjectBuilder sortBuilder = Json.createObjectBuilder();
 		String sort;
@@ -1038,7 +1039,7 @@ public class TestSearchApi {
 		checkResults(lsr, 0L, 1L, 2L, 3L, 4L);
 		checkInvestigation(lsr.getResults().get(0));
 		JsonValue searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 		lsr = searchApi.getResults(query, searchAfter, 6, null, investigationFields);
 		checkResults(lsr, 5L, 6L, 7L, 8L, 9L);
 		searchAfter = lsr.getSearchAfter();
@@ -1049,22 +1050,22 @@ public class TestSearchApi {
 		lsr = searchApi.getResults(query, 5, sort);
 		checkOrder(lsr, 0L, 1L, 2L, 3L, 4L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 		lsr = searchApi.getResults(query, searchAfter, 5, sort, investigationFields);
 		checkOrder(lsr, 5L, 6L, 7L, 8L, 9L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 
 		// Test searchAfter preserves the sorting of original search (desc)
 		sort = sortBuilder.add("date", "desc").build().toString();
 		lsr = searchApi.getResults(query, 5, sort);
 		checkOrder(lsr, 9L, 8L, 7L, 6L, 5L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 		lsr = searchApi.getResults(query, searchAfter, 5, sort, investigationFields);
 		checkOrder(lsr, 4L, 3L, 2L, 1L, 0L);
 		searchAfter = lsr.getSearchAfter();
-		assertNotNull(SEARCH_AFTER_NOT_NULL, searchAfter);
+		assertNotNull(searchAfter, SEARCH_AFTER_NOT_NULL);
 
 		// Test instrumentScientists only see their data
 		query = buildQuery("Investigation", "scientist_0", null, null, null, null, null);
@@ -1226,8 +1227,11 @@ public class TestSearchApi {
 
 	}
 
-	@Test
-	public void locking() throws IcatException {
+	@MethodSource("data")
+	@ParameterizedTest
+	public void locking(SearchApi searchApi) throws IcatException {
+		this.searchApi = searchApi;
+		searchApi.clear();
 		// Only LuceneApi needs manually locking
 		if (searchApi instanceof LuceneApi) {
 			logger.info("Performing locking tests for {}", searchApi.getClass().getSimpleName());
@@ -1256,9 +1260,12 @@ public class TestSearchApi {
 		}
 	}
 
-	@Ignore // Aggregating in real time is really slow, so don't test
-	@Test
-	public void fileSizeAggregation() throws IcatException {
+	@Disabled("Aggregating in real time is really slow, so don't test")
+	@MethodSource("data")
+	@ParameterizedTest
+	public void fileSizeAggregation(SearchApi searchApi) throws IcatException {
+		this.searchApi = searchApi;
+		searchApi.clear();
 		// Build entities
 		Investigation investigation = investigation(0, "name", date, date);
 		Dataset dataset = dataset(0, "name", date, date, investigation);
@@ -1304,8 +1311,11 @@ public class TestSearchApi {
 		assertEquals(expectedFileCount, fileCount);
 	}
 
-	@Test
-	public void modifyDatafile() throws IcatException {
+	@MethodSource("data")
+	@ParameterizedTest
+	public void modifyDatafile(SearchApi searchApi) throws IcatException {
+		this.searchApi = searchApi;
+		searchApi.clear();
 		// Build entities
 		DatafileFormat pdfFormat = datafileFormat(0, "pdf");
 		DatafileFormat pngFormat = datafileFormat(0, "png");
@@ -1390,8 +1400,11 @@ public class TestSearchApi {
 		checkResults(searchApi.getResults(pngQuery, 5));
 	}
 
-	@Test
-	public void unitConversion() throws IcatException {
+	@MethodSource("data")
+	@ParameterizedTest
+	public void unitConversion(SearchApi searchApi) throws IcatException {
+		this.searchApi = searchApi;
+		searchApi.clear();
 		// Build queries for raw and SI values
 		JsonObjectBuilder objectBuilder = Json.createObjectBuilder();
 		String lowKey = "272.5_273.5";
@@ -1450,8 +1463,11 @@ public class TestSearchApi {
 		checkFacets(searchApi.facetSearch("InvestigationParameter", systemFacetQuery, 5, 5), noneExpectedFacet);
 	}
 
-	@Test
-	public void exactFilter() throws IcatException {
+	@MethodSource("data")
+	@ParameterizedTest
+	public void exactFilter(SearchApi searchApi) throws IcatException {
+		this.searchApi = searchApi;
+		searchApi.clear();
 		// Build entities
 		Investigation numericInvestigation = investigation(0, "numeric", date, date);
 		Investigation rangeInvestigation = investigation(1, "range", date, date);
@@ -1494,8 +1510,11 @@ public class TestSearchApi {
 		checkResults(lsr, 1L);
 	}
 
-	@Test
-	public void sampleParameters() throws IcatException {
+	@MethodSource("data")
+	@ParameterizedTest
+	public void sampleParameters(SearchApi searchApi) throws IcatException {
+		this.searchApi = searchApi;
+		searchApi.clear();
 		// Build entities
 		Investigation investigation = investigation(0, "investigation", date, date);
 		Dataset dataset = dataset(1, "dataset", date, date, investigation);

--- a/src/test/java/org/icatproject/core/oldparser/TestComparisonPredicate.java
+++ b/src/test/java/org/icatproject/core/oldparser/TestComparisonPredicate.java
@@ -1,7 +1,7 @@
 package org.icatproject.core.oldparser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 
@@ -10,11 +10,8 @@ import org.icatproject.core.entity.Dataset;
 import org.icatproject.core.entity.DatasetParameter;
 import org.icatproject.core.entity.EntityBaseBean;
 import org.icatproject.core.entity.ParameterType;
-import org.icatproject.core.oldparser.ComparisonPredicate;
-import org.icatproject.core.oldparser.OldInput;
-import org.icatproject.core.oldparser.OldToken;
-import org.icatproject.core.oldparser.OldTokenizer;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 public class TestComparisonPredicate {
 

--- a/src/test/java/org/icatproject/core/oldparser/TestDagHandler.java
+++ b/src/test/java/org/icatproject/core/oldparser/TestDagHandler.java
@@ -1,8 +1,9 @@
 package org.icatproject.core.oldparser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.HashSet;
 import java.util.Set;
@@ -23,8 +24,8 @@ import org.icatproject.core.entity.InvestigationInstrument;
 import org.icatproject.core.entity.Job;
 import org.icatproject.core.entity.ParameterType;
 import org.icatproject.core.entity.User;
-import org.icatproject.core.oldparser.DagHandler;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 public class TestDagHandler {
 
@@ -39,15 +40,18 @@ public class TestDagHandler {
 		DagHandler.checkIncludes(Dataset.class, es);
 	}
 
-	@Test(expected = IcatException.class)
+	@Test
 	public void good2() throws Exception {
 		Set<Class<? extends EntityBaseBean>> es = new HashSet<Class<? extends EntityBaseBean>>();
 		es.add(Investigation.class);
 		es.add(Datafile.class);
 		es.add(DatasetParameter.class);
 		es.add(User.class);
-		DagHandler.findSteps(Dataset.class, es);
-		DagHandler.checkIncludes(Dataset.class, es);
+		assertThrows(IcatException.class, () -> {
+			DagHandler.findSteps(Dataset.class, es);
+			// The line above throws the exception. The line below is never executed.
+			DagHandler.checkIncludes(Dataset.class, es);
+		});
 	}
 
 	@Test

--- a/src/test/java/org/icatproject/core/oldparser/TestTokenizer.java
+++ b/src/test/java/org/icatproject/core/oldparser/TestTokenizer.java
@@ -1,14 +1,11 @@
 package org.icatproject.core.oldparser;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 
-import org.icatproject.core.oldparser.OldLexerException;
-import org.icatproject.core.oldparser.OldToken;
-import org.icatproject.core.oldparser.OldTokenizer;
-import org.junit.Test;
-
+import org.junit.jupiter.api.Test;
 
 public class TestTokenizer {
 
@@ -45,7 +42,7 @@ public class TestTokenizer {
 			assertEquals(tostrings[i++], t.toString());
 		}
 	}
-	
+
 	@Test
 	public void testQuotes() throws Exception {
 		List<OldToken> tokens = OldTokenizer.getTokens("c='aaa', d='bbb''qqq', e = ' ', f = '', g = ''''''");
@@ -57,24 +54,24 @@ public class TestTokenizer {
 		}
 	}
 
-	@Test(expected = OldLexerException.class)
+	@Test
 	public void testBad1() throws Exception {
-		OldTokenizer.getTokens("!");
+		assertThrows(OldLexerException.class, () -> OldTokenizer.getTokens("!"));
 	}
 
-	@Test(expected = OldLexerException.class)
+	@Test
 	public void testBad2() throws Exception {
-		OldTokenizer.getTokens("! ");
+		assertThrows(OldLexerException.class, () -> OldTokenizer.getTokens("! "));
 	}
 
-	@Test(expected = OldLexerException.class)
+	@Test
 	public void testBad3() throws Exception {
-		OldTokenizer.getTokens("'abcds''qwe ");
+		assertThrows(OldLexerException.class, () -> OldTokenizer.getTokens("'abcds''qwe "));
 	}
-	
-	@Test(expected = OldLexerException.class)
+
+	@Test
 	public void testBad4() throws Exception {
-		OldTokenizer.getTokens("{ts 1950-01-21T02:00:00}");
+		assertThrows(OldLexerException.class, () -> OldTokenizer.getTokens("{ts 1950-01-21T02:00:00}"));
 	}
 
 }

--- a/src/test/java/org/icatproject/core/parser/TestFrom.java
+++ b/src/test/java/org/icatproject/core/parser/TestFrom.java
@@ -1,7 +1,7 @@
 package org.icatproject.core.parser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Arrays;
 import java.util.HashSet;
@@ -13,7 +13,8 @@ import org.icatproject.core.entity.DatafileFormat;
 import org.icatproject.core.entity.Dataset;
 import org.icatproject.core.entity.Investigation;
 import org.icatproject.core.entity.InvestigationType;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 public class TestFrom {
 

--- a/src/test/java/org/icatproject/core/parser/TestRuleWhat.java
+++ b/src/test/java/org/icatproject/core/parser/TestRuleWhat.java
@@ -1,11 +1,12 @@
 package org.icatproject.core.parser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import org.icatproject.core.entity.Dataset;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 public class TestRuleWhat {
 

--- a/src/test/java/org/icatproject/core/parser/TestSelect.java
+++ b/src/test/java/org/icatproject/core/parser/TestSelect.java
@@ -1,13 +1,13 @@
 package org.icatproject.core.parser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestSelect {
 

--- a/src/test/java/org/icatproject/core/parser/TestTokenizer.java
+++ b/src/test/java/org/icatproject/core/parser/TestTokenizer.java
@@ -1,10 +1,11 @@
 package org.icatproject.core.parser;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.List;
 
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
 
 public class TestTokenizer {
 
@@ -58,24 +59,24 @@ public class TestTokenizer {
 		}
 	}
 
-	@Test(expected = LexerException.class)
+	@Test
 	public void testBad1() throws Exception {
-		Tokenizer.getTokens("!");
+		assertThrows(LexerException.class, () -> Tokenizer.getTokens("!"));
 	}
 
-	@Test(expected = LexerException.class)
+	@Test
 	public void testBad2() throws Exception {
-		Tokenizer.getTokens("! ");
+		assertThrows(LexerException.class, () -> Tokenizer.getTokens("! "));
 	}
 
-	@Test(expected = LexerException.class)
+	@Test
 	public void testBad3() throws Exception {
-		Tokenizer.getTokens("'abcds''qwe ");
+		assertThrows(LexerException.class, () -> Tokenizer.getTokens("'abcds''qwe "));
 	}
 
-	@Test(expected = LexerException.class)
+	@Test
 	public void testBad4() throws Exception {
-		Tokenizer.getTokens("{ts 1950-01-21T02:00:00}");
+		assertThrows(LexerException.class, () -> Tokenizer.getTokens("{ts 1950-01-21T02:00:00}"));
 	}
 
 }

--- a/src/test/java/org/icatproject/exposed/TestICATRest.java
+++ b/src/test/java/org/icatproject/exposed/TestICATRest.java
@@ -1,9 +1,7 @@
 package org.icatproject.exposed;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.fail;
-import org.junit.Test;
-import org.junit.BeforeClass;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.InvocationTargetException;
@@ -18,10 +16,12 @@ import java.math.BigInteger;
 import jakarta.json.Json;
 import jakarta.json.stream.JsonGenerator;
 
-import org.icatproject.exposed.ICATRest;
 import org.icatproject.core.entity.ParameterValueType;
 import org.icatproject.core.entity.StudyStatus;
 import org.icatproject.core.IcatException;
+
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
 
 public class TestICATRest {
 
@@ -30,7 +30,7 @@ public class TestICATRest {
 
 	private final static DateFormat df8601 = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSXXX");
 
-	@BeforeClass
+	@BeforeAll
 	public static void setup() throws Exception {
 
 		jsoniseArray = icatRest.getClass().getDeclaredMethod("jsonise", Object.class, JsonGenerator.class);

--- a/src/test/java/org/icatproject/exposed/parser/TestImportParser.java
+++ b/src/test/java/org/icatproject/exposed/parser/TestImportParser.java
@@ -1,9 +1,10 @@
 package org.icatproject.exposed.parser;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.Date;
 import java.util.List;
@@ -11,19 +12,18 @@ import java.util.List;
 import org.icatproject.core.IcatException;
 import org.icatproject.core.manager.Porter;
 import org.icatproject.core.manager.importParser.TableField;
-
 import org.icatproject.core.manager.importParser.ParserException;
 import org.icatproject.core.manager.importParser.Table;
-
 import org.icatproject.core.manager.importParser.Input;
 import org.icatproject.core.manager.importParser.Token;
 import org.icatproject.core.manager.importParser.Token.Type;
 import org.icatproject.core.manager.importParser.Tokenizer;
-import org.junit.Test;
+
+import org.junit.jupiter.api.Test;
 
 public class TestImportParser {
 
-	@Test()
+	@Test
 	public void testDataCollection() throws Exception {
 		Table t = new Table(new Input(
 				Tokenizer.getTokens(" DataCollection(?:0)")));
@@ -40,7 +40,7 @@ public class TestImportParser {
 		assertEquals(1, tableFields.size());
 	}
 
-	@Test()
+	@Test
 	public void testJob() throws Exception {
 		Input input = new Input(
 				Tokenizer
@@ -96,18 +96,17 @@ public class TestImportParser {
 		assertEquals(3, tableFields.size());
 	}
 
-	@Test(expected = ParserException.class)
+	@Test
 	public void testBadFacility() throws Exception {
 		Input input = new Input(
 				Tokenizer
 						.getTokens(" Facility (createId:0, createTime:1,  "
 								+ "modId : 2,  modTime: 3, name :4, daysUntilRelease:5))"));
 		new Table(input);
-		input.checkEnded();
-
+		assertThrows(ParserException.class, () -> input.checkEnded());
 	}
 
-	@Test()
+	@Test
 	public void testFacility() throws Exception {
 		Input input = new Input(
 				Tokenizer
@@ -185,7 +184,7 @@ public class TestImportParser {
 		assertEquals(2, tableFields.size());
 	}
 
-	@Test()
+	@Test
 	public void testDatafile() throws Exception {
 		Table t = new Table(
 				new Input(
@@ -239,7 +238,7 @@ public class TestImportParser {
 		assertEquals(3, tableFields.size());
 	}
 
-	@Test()
+	@Test
 	public void testDataset() throws Exception {
 		Table t = new Table(
 				new Input(
@@ -312,7 +311,7 @@ public class TestImportParser {
 		assertEquals(5, tableFields.size());
 	}
 
-	@Test()
+	@Test
 	public void testInvestigation() throws Exception {
 		Table t = new Table(
 				new Input(
@@ -372,7 +371,7 @@ public class TestImportParser {
 		assertEquals(4, tableFields.size());
 	}
 
-	@Test()
+	@Test
 	public void testParameterType() throws Exception {
 		Table t = new Table(
 				new Input(

--- a/src/test/java/org/icatproject/integration/TestDataPublication.java
+++ b/src/test/java/org/icatproject/integration/TestDataPublication.java
@@ -1,6 +1,6 @@
 package org.icatproject.integration;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
@@ -15,10 +15,11 @@ import org.icatproject.DatasetType;
 import org.icatproject.Facility;
 import org.icatproject.Investigation;
 import org.icatproject.InvestigationType;
-import org.junit.After;
-import org.junit.Before;
-import org.junit.BeforeClass;
-import org.junit.Test;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * Tests for the DataPublication functionality added in ICAT 5.0
@@ -27,7 +28,7 @@ public class TestDataPublication {
 
 	private static WSession session;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws Exception {
 		try {
 			session = new WSession();
@@ -37,12 +38,12 @@ public class TestDataPublication {
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public void initializeSession() throws Exception {
 		session.setAuthz();
 	}
 
-	@After
+	@AfterEach
 	public void clearSession() throws Exception {
         // delete the Facility objects (including children)
         // and also DataCollection and Study objects (can span Facilities)
@@ -102,7 +103,7 @@ public class TestDataPublication {
 
 		// now find and check them
 		List<Object> results1 = session.search("SELECT dp FROM DataPublication dp WHERE dp.type IS NULL INCLUDE dp.dates");
-		assertEquals(results1.size(), 1);
+		assertEquals(1, results1.size());
 		DataPublication dp1 = (DataPublication)results1.get(0);
 		System.out.println("Found dp1 with ID: " + dp1.getId());
 		assertEquals(dataPublicationNoType.getId(), dp1.getId());
@@ -111,13 +112,13 @@ public class TestDataPublication {
 		assertEquals(testDateString, ((DataPublicationDate)dp1.getDates().get(0)).getDate());
 
 		List<Object> results2 = session.search("SELECT dp FROM DataPublication dp WHERE dp.type.name = 'investigation'");
-		assertEquals(results2.size(), 1);
+		assertEquals(1, results2.size());
 		DataPublication dp2 = (DataPublication)results2.get(0);
 		System.out.println("Found dp2 with ID: " + dp2.getId());
 		assertEquals(dataPublicationInvType.getId(), dp2.getId());
 
 		List<Object> results3 = session.search("SELECT dp FROM DataPublication dp WHERE dp.type.name = 'user-defined'");
-		assertEquals(results3.size(), 1);
+		assertEquals(1, results3.size());
 		DataPublication dp3 = (DataPublication)results3.get(0);
 		System.out.println("Found dp3 with ID: " + dp3.getId());
 		assertEquals(dataPublicationUserType.getId(), dp3.getId());

--- a/src/test/java/org/icatproject/integration/TestRS.java
+++ b/src/test/java/org/icatproject/integration/TestRS.java
@@ -1,21 +1,14 @@
 package org.icatproject.integration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.Before;
-import org.junit.After;
-import org.junit.rules.ErrorCollector;
 import static org.hamcrest.CoreMatchers.equalTo;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.isA;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -67,6 +60,13 @@ import org.icatproject.EntityBaseBean;
 import org.icatproject.Facility;
 import org.icatproject.PublicStep;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.junit.rules.ErrorCollector;
+
 /**
  * These tests are for those aspects that cannot be tested by the core tests. In
  * particular does the INCLUDE mechanism work properly.
@@ -106,7 +106,7 @@ public class TestRS {
 		searchApi.clear();
 	}
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws Exception {
 		try {
 			wSession = new WSession();
@@ -116,12 +116,12 @@ public class TestRS {
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public void initializeSession() throws Exception {
 		wSession.setAuthz();
 	}
 
-	@After
+	@AfterEach
 	public void clearSession() throws Exception {
 		wSession.clear();
 		wSession.clearAuthz();
@@ -143,7 +143,7 @@ public class TestRS {
 		return icat.login("db", credentials);
 	}
 
-	@Ignore("Test fails because of bug in eclipselink")
+	@Disabled("Test fails because of bug in eclipselink")
 	@Test
 	public void testDistinctBehaviour() throws Exception {
 		Session session = rootSession();
@@ -734,13 +734,13 @@ public class TestRS {
 		JsonArray facets = buildFacetRequest("Datafile");
 		responseObject = searchDatafiles(session, null, null, null, null, null, null, 10, null, facets, 3);
 		assertFalse(responseObject.containsKey("search_after"));
-		assertFalse(NO_DIMENSIONS, responseObject.containsKey("dimensions"));
+		assertFalse(responseObject.containsKey("dimensions"), NO_DIMENSIONS);
 
 		// Test no facets match on DatafileParameters due to lack of READ access
 		facets = buildFacetRequest("DatafileParameter");
 		responseObject = searchDatafiles(session, null, null, null, null, null, null, 10, null, facets, 3);
 		assertFalse(responseObject.containsKey("search_after"));
-		assertFalse(NO_DIMENSIONS, responseObject.containsKey("dimensions"));
+		assertFalse(responseObject.containsKey("dimensions"), NO_DIMENSIONS);
 
 		// Test facets match on DatafileParameters
 		wSession.addRule(null, "DatafileParameter", "R");
@@ -871,8 +871,7 @@ public class TestRS {
 		facets = buildFacetRequest("DatasetParameter");
 		responseObject = searchDatasets(session, null, null, null, null, null, null, 10, null, facets, 5);
 		assertFalse(responseObject.containsKey("search_after"));
-		assertFalse(NO_DIMENSIONS,
-				responseObject.containsKey("dimensions"));
+		assertFalse(responseObject.containsKey("dimensions"), NO_DIMENSIONS);
 
 		// Test facets match on DatasetParameters
 		wSession.addRule(null, "DatasetParameter", "R");
@@ -1028,7 +1027,7 @@ public class TestRS {
 		responseObject = searchInvestigations(session, null, null, null, null, null, null, null, 10, null, facets,
 				3);
 		assertFalse(responseObject.containsKey("search_after"));
-		assertFalse(NO_DIMENSIONS, responseObject.containsKey("dimensions"));
+		assertFalse(responseObject.containsKey("dimensions"), NO_DIMENSIONS);
 
 		// Test facets match on InvestigationParameters
 		wSession.addRule(null, "InvestigationParameter", "R");
@@ -1043,7 +1042,7 @@ public class TestRS {
 		responseObject = searchInvestigations(session, null, null, null, null, null, null, null, 10, null, facets,
 				3);
 		assertFalse(responseObject.containsKey("search_after"));
-		assertFalse(NO_DIMENSIONS, responseObject.containsKey("dimensions"));
+		assertFalse(responseObject.containsKey("dimensions"), NO_DIMENSIONS);
 
 		// Test facets match on Sample
 		wSession.addRule(null, "Sample", "R");
@@ -1103,12 +1102,12 @@ public class TestRS {
 			List<Long> expectedCounts) {
 		Set<String> responseKeys = responseObject.keySet();
 		String dimensionsMessage = "Expected responseObject to contain 'dimensions', but it had keys " + responseKeys;
-		assertTrue(dimensionsMessage, responseObject.containsKey("dimensions"));
+		assertTrue(responseObject.containsKey("dimensions"), dimensionsMessage);
 
 		JsonObject dimensions = responseObject.getJsonObject("dimensions");
 		Set<String> dimensionKeys = dimensions.keySet();
 		String dimensionMessage = "Expected 'dimensions' to contain " + dimension + " but keys were " + dimensionKeys;
-		assertTrue(dimensionMessage, dimensions.containsKey(dimension));
+		assertTrue(dimensions.containsKey(dimension), dimensionMessage);
 
 		JsonObject labelsObject = dimensions.getJsonObject(dimension);
 		assertEquals(expectedLabels.size(), labelsObject.size());
@@ -1144,9 +1143,9 @@ public class TestRS {
 		assertEquals(expectations.size(), results.size());
 		for (int i = 0; i < expectations.size(); i++) {
 			JsonObject result = results.getJsonObject(i);
-			assertTrue("id not present in " + result.toString(), result.containsKey("id"));
+			assertTrue(result.containsKey("id"), "id not present in " + result.toString());
 			String message = "score " + (scored ? "not " : "") + "present in " + result.toString();
-			assertEquals(message, scored, result.containsKey("score"));
+			assertEquals(scored, result.containsKey("score"), message);
 
 			assertTrue(result.containsKey("source"));
 			JsonObject source = result.getJsonObject("source");
@@ -1156,12 +1155,11 @@ public class TestRS {
 				String key = entry.getKey();
 				String value = entry.getValue();
 				if (value == null) {
-					assertFalse("Source " + source.toString() + " should NOT contain " + key,
-							source.containsKey(key));
+					assertFalse(source.containsKey(key), "Source " + source.toString() + " should NOT contain " + key);
 				} else if (value.equals("notNull")) {
-					assertTrue("Source " + source.toString() + " should contain " + key, source.containsKey(key));
+					assertTrue(source.containsKey(key), "Source " + source.toString() + " should contain " + key);
 				} else {
-					assertTrue("Source " + source.toString() + " should contain " + key, source.containsKey(key));
+					assertTrue(source.containsKey(key), "Source " + source.toString() + " should contain " + key);
 					assertEquals(value, source.getString(key));
 				}
 			}
@@ -1409,7 +1407,7 @@ public class TestRS {
 				.getJsonObject(0).getJsonObject("Investigation");
 		Pattern p = Pattern.compile("^\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}.\\d{3}");
 		for (String name : Arrays.asList("createTime", "modTime", "startDate", "endDate")) {
-			assertTrue(name + ": " + inv.getString(name), p.matcher(inv.getString(name)).find());
+			assertTrue(p.matcher(inv.getString(name)).find(), name + ": " + inv.getString(name));
 		}
 
 		// Make sure all types are handled properly
@@ -1531,7 +1529,7 @@ public class TestRS {
 			JsonObject result = results.getJsonObject(0);
 			JsonObject investigation = result.getJsonObject("Investigation");
 			String visitId = investigation.getString("visitId", null);
-			assertEquals("Wrong visitId in " + investigation.toString(), "zero", visitId);
+			assertEquals("zero", visitId, "Wrong visitId in " + investigation.toString());
 
 			query = "SELECT f.investigationTypes FROM Facility f";
 			wSession.addRule(null, "InvestigationType", "R");
@@ -2380,10 +2378,10 @@ public class TestRS {
 		for (String line : restrictedLines) {
 			System.out.println(line);
 			containsInvestigations = containsInvestigations || line.startsWith("Investigation");
-			assertFalse("Dataset" + restrictiveMessage, line.startsWith("Dataset"));
-			assertFalse("Facility" + restrictiveMessage, line.startsWith("Facility"));
+			assertFalse(line.startsWith("Dataset"), "Dataset" + restrictiveMessage);
+			assertFalse(line.startsWith("Facility"), "Facility" + restrictiveMessage);
 		}
-		assertTrue("Investigation" + permissiveMessage, containsInvestigations);
+		assertTrue(containsInvestigations, "Investigation" + permissiveMessage);
 
 		containsInvestigations = false;
 		boolean containsDatasets = false;
@@ -2394,15 +2392,15 @@ public class TestRS {
 			containsDatasets = containsDatasets || line.startsWith("Dataset");
 			containsFacilities = containsFacilities || line.startsWith("Facility");
 		}
-		assertTrue("Investigation" + permissiveMessage, containsInvestigations);
-		assertTrue("Dataset" + permissiveMessage, containsDatasets);
-		assertTrue("Facility" + permissiveMessage, containsFacilities);
+		assertTrue(containsInvestigations, "Investigation" + permissiveMessage);
+		assertTrue(containsDatasets, "Dataset" + permissiveMessage);
+		assertTrue(containsFacilities, "Facility" + permissiveMessage);
 
 		Files.delete(dump1);
 		Files.delete(dump2);
 	}
 
-	@Ignore("Test fails - appears brittle to differences in timezone")
+	@Disabled("Test fails - appears brittle to differences in timezone")
 	@Test
 	public void exportMetaDataQuery() throws Exception {
 		Session session = rootSession();
@@ -2427,8 +2425,8 @@ public class TestRS {
 		ts("Create dump ALL");
 		long n = dump.toFile().length();
 
-		assertTrue("Size is dependent upon time zone in which test is run " + n,
-				n == 2686 || n == 1518 || n == 2771 || n == 2776 || n == 2691);
+		assertTrue(n == 2686 || n == 1518 || n == 2771 || n == 2776 || n == 2691,
+				"Size is dependent upon time zone in which test is run " + n);
 
 		session.importMetaData(dump, DuplicateAction.CHECK, Attributes.ALL);
 		Files.delete(dump);

--- a/src/test/java/org/icatproject/integration/TestWS.java
+++ b/src/test/java/org/icatproject/integration/TestWS.java
@@ -1,11 +1,11 @@
 package org.icatproject.integration;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.text.DateFormat;
 import java.text.SimpleDateFormat;
@@ -59,11 +59,12 @@ import org.icatproject.User;
 import org.icatproject.UserGroup;
 import org.icatproject.core.manager.EntityInfoHandler;
 import org.icatproject.utils.ContainerGetter.ContainerType;
-import org.junit.BeforeClass;
-import org.junit.Ignore;
-import org.junit.Test;
-import org.junit.Before;
-import org.junit.After;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
 
 /**
  * These tests are for those aspects that cannot be tested by the core tests. In
@@ -75,7 +76,7 @@ public class TestWS {
 	private static Random random;
 	private static WSession session;
 
-	@BeforeClass
+	@BeforeAll
 	public static void beforeClass() throws Exception {
 		try {
 			random = new Random();
@@ -86,12 +87,12 @@ public class TestWS {
 		}
 	}
 
-	@Before
+	@BeforeEach
 	public void initializeSession() throws Exception {
 		session.setAuthz();
 	}
 
-	@After
+	@AfterEach
 	public void clearSession() throws Exception {
 		session.clear();
 		session.clearAuthz();
@@ -728,7 +729,7 @@ public class TestWS {
 		}
 	}
 
-	@Ignore
+	@Disabled
 	@Test
 	public void manyBigGets() throws Exception {
 		Facility facility = session.createFacility("Test Facility", 90);
@@ -995,7 +996,7 @@ public class TestWS {
 		}
 	}
 
-	@Ignore("Needs Oracle for this test to be useful")
+	@Disabled("Needs Oracle for this test to be useful")
 	@Test
 	public void getInvestigationWithVeryManyDatasets() throws Exception {
 		WSession piOneSession = session.getSession("db", "username", "piOne", "password", "piOne");
@@ -1118,9 +1119,9 @@ public class TestWS {
 			assertTrue(df.getName().equals("wib1") || df.getName().equals("wib2"));
 			String tn = df.getDatafileFormat().getName();
 			if (df.getName().equals("wib1")) {
-				assertEquals(tn, "png");
+				assertEquals("png", tn);
 			} else {
-				assertEquals(tn, "bmp");
+				assertEquals("bmp", tn);
 			}
 		}
 
@@ -1190,21 +1191,21 @@ public class TestWS {
 
 		List<?> results = session.search("Dataset.id order by id");
 
-		assertEquals("Count", 4, results.size());
+		assertEquals(4, results.size(), "Count");
 
 		results = session.search("Dataset [name = 'Wibble']");
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 		Dataset ds = (Dataset) results.get(0);
-		assertEquals("No files", 0, ds.getDatafiles().size());
-		assertEquals("No params", 0, ds.getParameters().size());
-		assertNull("No inv", ds.getInvestigation());
+		assertEquals(0, ds.getDatafiles().size(), "No files");
+		assertEquals(0, ds.getParameters().size(), "No params");
+		assertNull(ds.getInvestigation(), "No inv");
 
 		results = session.search("Dataset INCLUDE Datafile[name = 'Wibble']");
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 		ds = (Dataset) results.get(0);
-		assertEquals("Files", 2, ds.getDatafiles().size());
-		assertEquals("No params", 0, ds.getParameters().size());
-		assertNull("No inv", ds.getInvestigation());
+		assertEquals(2, ds.getDatafiles().size(), "Files");
+		assertEquals(0, ds.getParameters().size(), "No params");
+		assertNull(ds.getInvestigation(), "No inv");
 
 		try {
 			results = session.search("Dataset INCLUDE 1, Datafile [name = 'Wibble']");
@@ -1228,58 +1229,58 @@ public class TestWS {
 		}
 
 		results = session.search("Dataset INCLUDE 1 [name = 'Wibble']");
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 		ds = (Dataset) results.get(0);
-		assertEquals("No files", 0, ds.getDatafiles().size());
-		assertEquals("No params", 0, ds.getParameters().size());
-		assertNotNull("Inv", ds.getInvestigation());
+		assertEquals(0, ds.getDatafiles().size(), "No files");
+		assertEquals(0, ds.getParameters().size(), "No params");
+		assertNotNull(ds.getInvestigation(), "Inv");
 
 		results = session.search("Dataset INCLUDE DatasetParameter [name = 'Wibble']");
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 		ds = (Dataset) results.get(0);
-		assertEquals("No Files", 0, ds.getDatafiles().size());
-		assertEquals("Params", 1, ds.getParameters().size());
-		assertNull("No inv", ds.getInvestigation());
+		assertEquals(0, ds.getDatafiles().size(), "No Files");
+		assertEquals(1, ds.getParameters().size(), "Params");
+		assertNull(ds.getInvestigation(), "No inv");
 
 		results = session.search("Dataset INCLUDE Datafile, DatasetParameter [name = 'Wibble']");
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 		ds = (Dataset) results.get(0);
-		assertEquals("Files", 2, ds.getDatafiles().size());
-		assertEquals("Params", 1, ds.getParameters().size());
-		assertNull("No inv", ds.getInvestigation());
+		assertEquals(2, ds.getDatafiles().size(), "Files");
+		assertEquals(1, ds.getParameters().size(), "Params");
+		assertNull(ds.getInvestigation(), "No inv");
 
 		results = session.search("Dataset INCLUDE Datafile, DatasetParameter, Investigation [name = 'Wibble']");
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 		ds = (Dataset) results.get(0);
-		assertEquals("Files", 2, ds.getDatafiles().size());
-		assertEquals("Params", 1, ds.getParameters().size());
-		assertNotNull("Inv", ds.getInvestigation());
+		assertEquals(2, ds.getDatafiles().size(), "Files");
+		assertEquals(1, ds.getParameters().size(), "Params");
+		assertNotNull(ds.getInvestigation(), "Inv");
 
 		results = session.search("Job");
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 		Job job = (Job) results.get(0);
-		assertNull("InputDataset", job.getInputDataCollection());
-		assertNull("OutputDataset", job.getOutputDataCollection());
+		assertNull(job.getInputDataCollection(), "InputDataset");
+		assertNull(job.getOutputDataCollection(), "OutputDataset");
 
 		results = session.search("Job");
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 		job = (Job) results.get(0);
-		assertNull("Application", job.getApplication());
+		assertNull(job.getApplication(), "Application");
 
 		results = session.search("Job INCLUDE Application");
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 		job = (Job) results.get(0);
-		assertNotNull("Application", job.getApplication());
+		assertNotNull(job.getApplication(), "Application");
 
 		results = session.search("Application");
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 		Application application = (Application) results.get(0);
-		assertEquals("InputDataset", 0, application.getJobs().size());
+		assertEquals(0, application.getJobs().size(), "InputDataset");
 
 		results = session.search("Application INCLUDE Job");
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 		application = (Application) results.get(0);
-		assertEquals("InputDataset", 1, application.getJobs().size());
+		assertEquals(1, application.getJobs().size(), "InputDataset");
 
 		try {
 			results = session.search("Job INCLUDE InputDataset, InputDatafile, Dataset, Datafile");
@@ -1354,7 +1355,7 @@ public class TestWS {
 	public void login() throws Exception {
 		double rm = session.getRemainingMinutes();
 		assertTrue(rm > 0);
-		assertTrue("API version", session.getApiVersion().startsWith(version));
+		assertTrue(session.getApiVersion().startsWith(version), "API version");
 		assertEquals("db/notroot", session.getUserName());
 		Thread.sleep(10);
 		rm = session.getRemainingMinutes();
@@ -1547,52 +1548,52 @@ public class TestWS {
 
 		List<?> results = session.search(
 				"Dataset.id " + "<-> DatasetParameter[type.name = 'TIMESTAMP'] " + "<-> Investigation[name <> 12]");
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 
 		results = session.search("Datafile [name = 'fred'] <-> Dataset[id <> 42]");
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 
 		String query = "Dataset.id  ORDER BY id [type.name IN :types] <-> Investigation[id BETWEEN :lower AND :upper]";
 
 		query = query.replace(":lower", Long.toString(invId)).replace(":upper", Long.toString(invId)).replace(":types",
 				"('GS', 'GQ')");
 		results = session.search(query);
-		assertEquals("Count", 4, results.size());
+		assertEquals(4, results.size(), "Count");
 
 		query = "Dataset.id ORDER BY startDate [type.name IN :types AND name >= :lower AND name <= :upper]";
 		query = query.replace(":lower", "'Wabble'").replace(":upper", "'Wobble'").replace(":types", "('GS', 'GQ')");
 		results = session.search(query);
-		assertEquals("Count", 2, results.size());
+		assertEquals(2, results.size(), "Count");
 
 		query = "ParameterType.name [description LIKE 'F%']";
 		results = session.search(query);
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 		assertEquals("TIMESTAMP", results.get(0));
 
 		results = session.search("Datafile.name ORDER BY name");
-		assertEquals("Count", 6, results.size());
-		assertEquals("Result", "bill", results.get(0));
-		assertEquals("Result", "fred", results.get(1));
+		assertEquals(6, results.size(), "Count");
+		assertEquals("bill", results.get(0), "Result");
+		assertEquals("fred", results.get(1), "Result");
 
 		results = session.search(",1 Datafile.name ORDER BY name");
-		assertEquals("Count", 1, results.size());
-		assertEquals("Result", "bill", results.get(0));
+		assertEquals(1, results.size(), "Count");
+		assertEquals("bill", results.get(0), "Result");
 
 		results = session.search("1, Datafile.name ORDER BY name");
-		assertEquals("Count", 5, results.size());
-		assertEquals("Result", "fred", results.get(0));
+		assertEquals(5, results.size(), "Count");
+		assertEquals("fred", results.get(0), "Result");
 
 		results = session.search("1,1 Datafile.name ORDER BY name");
-		assertEquals("Count", 1, results.size());
-		assertEquals("Result", "fred", results.get(0));
+		assertEquals(1, results.size(), "Count");
+		assertEquals("fred", results.get(0), "Result");
 
 		results = session.search("100,1 Datafile.name ORDER BY name");
-		assertEquals("Count", 0, results.size());
+		assertEquals(0, results.size(), "Count");
 
 		results = session.search("0,100 Datafile.name ORDER BY name");
-		assertEquals("Count", 6, results.size());
-		assertEquals("Result", "bill", results.get(0));
-		assertEquals("Result", "fred", results.get(1));
+		assertEquals(6, results.size(), "Count");
+		assertEquals("bill", results.get(0), "Result");
+		assertEquals("fred", results.get(1), "Result");
 
 		results = session.search("Facility");
 		Facility facility = (Facility) results.get(0);
@@ -1690,7 +1691,7 @@ public class TestWS {
 				+ "investigation.investigationUsers as investigationUser, investigationUser.user as user "
 				+ "where user.name = :user ORDER BY investigation.startDate desc limit 0, 50 "
 				+ "include investigation.investigationInstruments.instrument");
-		assertEquals("Count", 2, results.size());
+		assertEquals(2, results.size(), "Count");
 
 		Date now = new Date(new Date().getTime() + 1001); // Move on a second
 		DateFormat df = new SimpleDateFormat("yyyy-MM-dd' 'HH:mm:ss");
@@ -1722,11 +1723,11 @@ public class TestWS {
 
 		results = session.search("SELECT ds.id FROM Dataset ds JOIN ds.parameters dsp JOIN ds.investigation inv"
 				+ " WHERE dsp.type.name = 'TIMESTAMP' AND inv.name <> 12");
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 
 		results = session
 				.search("SELECT df FROM Datafile df JOIN df.dataset ds WHERE df.name = 'fred' AND ds.id <> 42");
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 
 		String query = "SELECT ds.id FROM Dataset ds JOIN ds.investigation inv "
 				+ "WHERE ds.type.name IN :types AND inv.id BETWEEN :lower AND :upper " + "ORDER BY ds.id";
@@ -1734,60 +1735,60 @@ public class TestWS {
 				"('GS', 'GQ')");
 
 		results = session.search(query);
-		assertEquals("Count", 4, results.size());
+		assertEquals(4, results.size(), "Count");
 
 		query = "SELECT ds.id FROM Dataset ds WHERE ds.type.name IN :types AND ds.name >= :lower AND ds.name <= :upper ORDER BY ds.startDate";
 		query = query.replace(":lower", "'Wabble'").replace(":upper", "'Wobble'").replace(":types", "('GS', 'GQ')");
 		results = session.search(query);
-		assertEquals("Count", 2, results.size());
+		assertEquals(2, results.size(), "Count");
 
 		query = "SELECT pt.name FROM ParameterType pt WHERE pt.description LIKE 'F%'";
 		results = session.search(query);
-		assertEquals("Count", 1, results.size());
+		assertEquals(1, results.size(), "Count");
 		assertEquals("TIMESTAMP", results.get(0));
 
 		results = session.search("SELECT df.name FROM Datafile df ORDER BY df.name");
-		assertEquals("Count", 6, results.size());
-		assertEquals("Result", "bill", results.get(0));
-		assertEquals("Result", "fred", results.get(1));
+		assertEquals(6, results.size(), "Count");
+		assertEquals("bill", results.get(0), "Result");
+		assertEquals("fred", results.get(1), "Result");
 
 		results = session.search("SELECT df.name, df.fileSize FROM Datafile df ORDER BY df.name");
-		assertEquals("Count", 6, results.size());
+		assertEquals(6, results.size(), "Count");
 
-		assertEquals("Result", "bill", ((FieldSet) results.get(0)).getFields().get(0));
-		assertEquals("Result", 17L, ((FieldSet) results.get(0)).getFields().get(1));
-		assertEquals("Result", "fred", ((FieldSet) results.get(1)).getFields().get(0));
-		assertEquals("Result", 11L, ((FieldSet) results.get(1)).getFields().get(1));
+		assertEquals("bill", ((FieldSet) results.get(0)).getFields().get(0), "Result");
+		assertEquals(17L, ((FieldSet) results.get(0)).getFields().get(1), "Result");
+		assertEquals("fred", ((FieldSet) results.get(1)).getFields().get(0), "Result");
+		assertEquals(11L, ((FieldSet) results.get(1)).getFields().get(1), "Result");
 
 		results = session.search("SELECT df.name FROM Datafile df ORDER BY df.name LIMIT 0,1");
-		assertEquals("Count", 1, results.size());
-		assertEquals("Result", "bill", results.get(0));
+		assertEquals(1, results.size(), "Count");
+		assertEquals("bill", results.get(0), "Result");
 
 		results = session.search("SELECT df.name FROM Datafile df ORDER BY df.name LIMIT 1,100");
-		assertEquals("Count", 5, results.size());
-		assertEquals("Result", "fred", results.get(0));
+		assertEquals(5, results.size(), "Count");
+		assertEquals("fred", results.get(0), "Result");
 
 		results = session.search("SELECT df.name FROM Datafile df ORDER BY df.name LIMIT 1,1");
-		assertEquals("Count", 1, results.size());
-		assertEquals("Result", "fred", results.get(0));
+		assertEquals(1, results.size(), "Count");
+		assertEquals("fred", results.get(0), "Result");
 
 		results = session.search("SELECT df.name FROM Datafile df ORDER BY df.name LIMIT 100,1");
-		assertEquals("Count", 0, results.size());
+		assertEquals(0, results.size(), "Count");
 
 		results = session.search("SELECT df.name FROM Datafile df ORDER BY df.name LIMIT 0,100");
-		assertEquals("Count", 6, results.size());
-		assertEquals("Result", "bill", results.get(0));
-		assertEquals("Result", "fred", results.get(1));
+		assertEquals(6, results.size(), "Count");
+		assertEquals("bill", results.get(0), "Result");
+		assertEquals("fred", results.get(1), "Result");
 
 		results = session.search("SELECT ds.name from Dataset ds JOIN ds.datafiles df1 JOIN ds.datafiles df2 "
 				+ "WHERE df1.name = 'fred' AND df2.name = 'bill'");
-		assertEquals("Count", 1, results.size());
-		assertEquals("Result", "dfsin", results.get(0));
+		assertEquals(1, results.size(), "Count");
+		assertEquals("dfsin", results.get(0), "Result");
 
 		results = session.search("SELECT ds.name from Dataset ds JOIN ds.datafiles df1 JOIN ds.datafiles df2 "
 				+ "WHERE LOWER(df1.name) = 'fred' AND df2.name = LOWER('bill')");
-		assertEquals("Count", 1, results.size());
-		assertEquals("Result", "dfsin", results.get(0));
+		assertEquals(1, results.size(), "Count");
+		assertEquals("dfsin", results.get(0), "Result");
 
 		results = session.search("SELECT f FROM Facility f");
 		Facility facility = (Facility) results.get(0);
@@ -1849,13 +1850,13 @@ public class TestWS {
 		session.createFacility("TestX_Facility", 90);
 
 		query = "SELECT f.name FROM Facility f WHERE f.name LIKE 'Test__Facility'";
-		assertEquals("Count", 3, session.search(query).size());
+		assertEquals(3, session.search(query).size(), "Count");
 
 		query = "SELECT f.name FROM Facility f WHERE f.name LIKE 'Test$_$_Facility'";
-		assertEquals("Count", 0, session.search(query).size());
+		assertEquals(0, session.search(query).size(), "Count");
 
 		query = "SELECT f.name FROM Facility f WHERE f.name LIKE 'Test$_$_Facility' ESCAPE '$'";
-		assertEquals("Count", 1, session.search(query).size());
+		assertEquals(1, session.search(query).size(), "Count");
 
 		// Check that nulls are returned in FieldSets
 		results = session.search("SELECT null, max(i.id) FROM Investigation i");
@@ -1939,28 +1940,28 @@ public class TestWS {
 		for (EntityField field : ei.getFields()) {
 			if (field.getName().equals("id")) {
 				assertEquals("Long", field.getType());
-				assertEquals(false, field.isNotNullable());
-				assertEquals(null, field.getComment());
+				assertFalse(field.isNotNullable());
+				assertNull(field.getComment());
 				assertEquals(RelType.ATTRIBUTE, field.getRelType());
-				assertEquals(null, field.getStringLength());
+				assertNull(field.getStringLength());
 			} else if (field.getName().equals("facility")) {
 				assertEquals("Facility", field.getType());
-				assertEquals(true, field.isNotNullable());
-				assertEquals(null, field.getComment());
+				assertTrue(field.isNotNullable());
+				assertNull(field.getComment());
 				assertEquals(RelType.ONE, field.getRelType());
-				assertEquals(null, field.getStringLength());
+				assertNull(field.getStringLength());
 			} else if (field.getName().equals("title")) {
 				assertEquals("String", field.getType());
-				assertEquals(true, field.isNotNullable());
+				assertTrue(field.isNotNullable());
 				assertEquals("Full title of the investigation", field.getComment());
 				assertEquals(RelType.ATTRIBUTE, field.getRelType());
 				assertEquals((Integer) 255, field.getStringLength());
 			} else if (field.getName().equals("investigationUsers")) {
 				assertEquals("InvestigationUser", field.getType());
-				assertEquals(false, field.isNotNullable());
-				assertEquals(null, field.getComment());
+				assertFalse(field.isNotNullable());
+				assertNull(field.getComment());
 				assertEquals(RelType.MANY, field.getRelType());
-				assertEquals(null, field.getStringLength());
+				assertNull(field.getStringLength());
 			} else {
 				n++;
 			}


### PR DESCRIPTION
Upgrade from JUnit 4 to 5. Also upgrades the maven surefire and failsafe plugins for compatibility.

The main difference is that the optional message has moves from being the first argument to the last argument in assert methods.

This is required for quarkus because there is only a quarkus-junit5 extension.