### PR TITLE
Add a `DataPublication` and related objects to test data for class `TestRS`

### DIFF
--- a/src/test/java/org/icatproject/integration/TestRS.java
+++ b/src/test/java/org/icatproject/integration/TestRS.java
@@ -406,6 +406,22 @@ public class TestRS {
 		 */
 		JsonArray j_response = search(session, "SELECT j from Job j", 1);
 		collector.checkThat(j_response.getJsonObject(0).containsKey("Job"), is(true));
+
+		/*
+		 * Expected: <[{"DataPublication":{"id":6,"createId":"simple/root","createTime":
+		 * "2025-07-16T22:54:23.000+02:00","modId":"simple/root","modTime":
+		 * "2025-07-16T22:54:23.000+02:00","dates":[],"description":
+		 * "We provide the first 65535 integers [...] a one dimensional integer array.",
+		 * "fundingReferences":[],"pid":"DOI:00.0815/pub-00027","publicationDate":
+		 * "2022-10-31T00:00:00.000+01:00","relatedItems":[],"subject":
+		 * "integer sequence; OEIS; On-Line Encyclopedia of Integer Sequences",
+		 * "title":"Data from OEIS sequence A000027","users":[]}}]>
+		 */
+		JsonArray datapub_response = search(session, "SELECT d FROM DataPublication d", 1);
+		collector.checkThat(datapub_response.getJsonObject(0).containsKey("DataPublication"), is(true));
+		collector.checkThat(
+				datapub_response.getJsonObject(0).getJsonObject("DataPublication").getJsonString("title").getString(),
+				is("Data from OEIS sequence A000027"));
 	}
 
 	@Test

--- a/src/test/java/org/icatproject/integration/TestRS.java
+++ b/src/test/java/org/icatproject/integration/TestRS.java
@@ -384,8 +384,8 @@ public class TestRS {
 		 * 000Z","dataCollectionDatafiles":[],"dataCollectionDatasets":[],"jobsAsInput":[],"jobsAsOutput":[],"parameters
 		 * ":[]}}]>
 		 */
-		JsonArray dc_response = search(session, "SELECT dc from DataCollection dc", 3);
-		collector.checkThat(dc_response.size(), equalTo(3));
+		JsonArray dc_response = search(session, "SELECT dc from DataCollection dc", 4);
+		collector.checkThat(dc_response.size(), equalTo(4));
 		collector.checkThat(dc_response.getJsonObject(0).containsKey("DataCollection"), is(true));
 
 		/*

--- a/src/test/java/org/icatproject/integration/TestRS.java
+++ b/src/test/java/org/icatproject/integration/TestRS.java
@@ -2314,7 +2314,7 @@ public class TestRS {
 	private void exportMetaDataDump(Map<String, String> credentials) throws Exception {
 		ICAT icat = new ICAT(System.getProperty("serverUrl"));
 		Session session = icat.login("db", credentials);
-		Path path = Paths.get(this.getClass().getResource("/icat.port").toURI());
+		Path path = Paths.get(this.getClass().getResource("/icat-import-export.port").toURI());
 
 		Map<String, String> rootCredentials = new HashMap<>();
 		rootCredentials.put("username", "root");
@@ -2446,7 +2446,7 @@ public class TestRS {
 
 	private void importMetaData(Attributes attributes, String userName) throws Exception {
 		Session session = rootSession();
-		Path path = Paths.get(this.getClass().getResource("/icat.port").toURI());
+		Path path = Paths.get(this.getClass().getResource("/icat-import-export.port").toURI());
 
 		start = System.currentTimeMillis();
 		session.importMetaData(path, DuplicateAction.CHECK, attributes);

--- a/src/test/java/org/icatproject/integration/WSession.java
+++ b/src/test/java/org/icatproject/integration/WSession.java
@@ -195,7 +195,7 @@ public class WSession {
 	}
 
 	public void clear() throws Exception {
-		deleteAll(Arrays.asList("Facility", "DataCollection", "Study"));
+		deleteAll(Arrays.asList("Facility", "DataCollection", "Study", "FundingReference", "Technique"));
 	}
 
 	private void deleteAll(List<String> names) throws IcatException_Exception {

--- a/src/test/java/org/icatproject/integration/WSession.java
+++ b/src/test/java/org/icatproject/integration/WSession.java
@@ -387,6 +387,11 @@ public class WSession {
 		this.addFastRule("DataPublication", "CRUD");
 		this.addFastRule("DataPublicationType", "CRUD");
 		this.addFastRule("DataPublicationDate", "CRUD");
+		this.addFastRule("DataPublicationUser", "CRUD");
+		this.addFastRule("Affiliation", "CRUD");
+		this.addFastRule("RelatedItem", "CRUD");
+		this.addFastRule("DataPublicationFunding", "CRUD");
+		this.addFastRule("FundingReference", "CRUD");
 		snooze();
 	}
 

--- a/src/test/resources/icat-import-export.port
+++ b/src/test/resources/icat-import-export.port
@@ -1,0 +1,93 @@
+# Version of file format
+1.0
+
+User (name:0, fullName:1, familyName:2, givenName:3, affiliation:4)
+"db/tr", "Professor Tap Root", null, null, null
+"db/minion", "Mr Minion", null, null, null
+"db/fred", "Professor Fred Brown", "Brown", "Fred", null
+"db/lib","Dr. Horace Worblehat", "Worblehat", "Horace", "Unseen University"
+
+Facility ( name:0, daysUntilRelease:1, createId:2, createTime:3)
+"Test port facility", 90, "Zorro", 1920-05-16T16:58:26.12Z
+
+Instrument(facility(name:0), name:1, fullName:2, pid:3)
+"Test port facility", "EDDI", "EDDI - Energy Dispersive Diffraction", "ig:0815"
+
+InvestigationType (facility(name:0), name:1)
+"Test port facility", "atype"
+"Test port facility", "btype"
+
+ParameterType(facility(name:0), name:1, units:2, minimumNumericValue:3, applicableToInvestigation:4, applicableToDataset:5, applicableToDatafile:6, valueType:7, pid:8)
+"Test port facility", "temp", "degrees Kelvin", 73.4, true, true, true, NUMERIC, "pt:25c"
+"Test port facility", "pressure", "kPa", 73, null, true, true, numERIC, "pt:17a"
+"Test port facility", "colour", "name", null, true,true, true, STRING, null
+"Test port facility", "current", "amps", null, true,true, true, NUMERIC, null
+"Test port facility", "birthday", "date", null, true,true, true, DATE_AND_TIME, null
+
+Investigation(facility(name:0), name:1, visitId:2, type(facility(name:0), name:3),title:4,startDate:5,endDate:6)
+"Test port facility", "expt1", "zero", "atype", "a title at the beginning", 2010-01-01T00:00:00Z, 2010-12-31T23:59:59Z
+"Test port facility", "expt1", "one", "atype", "a title in the middle",2011-01-01T00:00:00Z, 2011-12-31T23:59:59Z
+"Test port facility", "expt1", "two", "atype", "a title at the end",2012-01-01T00:00:00Z, 2012-12-31T23:59:59Z
+
+InvestigationUser(investigation(facility(name:0), name:1, visitId:2),user(name:3), role:4)
+"Test port facility", "expt1", "zero", "db/tr", "troublemaker"
+"Test port facility", "expt1", "one", "db/tr", "PI"
+"Test port facility", "expt1", "two", "db/minion", "PI"
+"Test port facility", "expt1", "one", "db/minion", "PI"
+
+Shift(investigation(facility(name:0), name:1, visitId:2), startDate:3, endDate:4, comment:5, instrument(facility(name:0), name:6))
+"Test port facility", "expt1", "zero", 2013-12-31T12:00:00+01:00, 2013-12-31T23:59:59+01:00, "waiting", null
+"Test port facility", "expt1", "zero", 2014-01-01T00:00:00+01:00, 2014-01-01T18:00:00+01:00, "beamtime", "EDDI"
+"Test port facility", "expt1", "two", 2014-04-29T14:00:00+02:00, 2014-04-30T18:15:00+02:00, "preparing", null
+
+SampleType(facility(name:0), name:1, molecularFormula:2, safetyInformation:3)
+"Test port facility", "diamond", "C", "fairly harmless"
+"Test port facility", "graphite", "C", "bit messy"
+"Test port facility", "rust", "Fe3O4", "messy"
+
+Sample(investigation(facility(name:0), name:1, visitId:2), type(facility(name:0), name:3, molecularFormula:4), name:5, pid:6)
+"Test port facility", "expt1", "one", "diamond", "C", "Koh-I-Noor", "sdb:374717"
+"Test port facility", "expt1", "one", "rust",  "Fe3O4", "Ford\t\"Anglia\"", null
+
+InvestigationParameter(investigation(facility(name:0), name:1, visitId:2), type(facility(name:0), name:3 , units:4),stringValue:5)
+"Test port facility", "expt1", "one", "colour" , "name", "green"
+
+DatasetType(facility(name:0), name:1)
+"Test port facility", "calibration"
+
+Dataset (investigation(facility(name:0), name:1, visitId:2) , name:3, type(facility(name:0), name:4), complete:5, startDate:6, endDate:7 sample(investigation(facility(name:0), name:1, visitId:2), name:8), description:9)
+"Test port facility", "expt1", "one", "ds1", "calibration", true,  2014-05-16T16:58:26.12+12:30, 2014-05-16T16:58:26.12+12:30, "Koh-I-Noor", "alpha"
+"Test port facility", "expt1", "one", "ds2", "calibration", null,  2014-05-16T06:05:26.12Z, 2014-05-16T06:07:26.12+12:30,"Ford\t\"Anglia\"", "beta"
+"Test port facility", "expt1", "one", "ds3", "calibration", False, 2014-05-16T06:09:26.12+01:00, 2014-05-16T06:15:26.12+01:00, null, "gamma"
+"Test port facility", "expt1", "two", "ds3", "calibration", False, 2014-05-16T06:20:26.12, 2014-05-16T06:21:26.12, null, "delta"
+"Test port facility", "expt1", "two", "ds4", "calibration", False, 2014-05-16T06:31:26.12, 2014-05-16T06:32:26.12, null, "epsilon"
+
+DatasetParameter(dataset(investigation(facility(name:0), name:1, visitId:2) , name:3), type(facility(name:0), name:4 , units:5),stringValue:6, numericValue:7, dateTimeValue:8)
+"Test port facility", "expt1", "one", "ds3", "colour" , "name", "green", null, null
+"Test port facility", "expt1", "one", "ds3", "birthday", "date", null, null, 2014-05-16T16:58:26.12Z
+"Test port facility", "expt1", "one", "ds3", "current" , "amps", null, 150, null
+
+Datafile(dataset(investigation(facility(name:0), name:1, visitId:2), name:3), name:4, fileSize:5)
+"Test port facility", "expt1", "one", "ds2", "df1 \t \r \n \\ \f \b \' \"", 15
+"Test port facility", "expt1", "one", "ds2", "df2", 17
+"Test port facility", "expt1", "one", "ds2", "df3", 20
+
+DatafileParameter(datafile(dataset(investigation(facility(name:0), name:1, visitId:2) , name:3), name:4), type(facility(name:0), name:5 , units:6),stringValue:7, numericValue:8, dateTimeValue:9)
+"Test port facility", "expt1", "one", "ds2", "df2", "colour" , "name", "green", null, null
+
+Application(facility(name:0), name:1, version:2)
+"Test port facility", "aprog", "1.2.3"
+"Test port facility", "aprog", "1.2.6"
+
+DataCollection(?:0)
+"a"
+"b"
+"c"
+
+DataCollectionDatafile(datafile(dataset(investigation(facility(name:0), name:1, visitId:2), name:3), name:4), dataCollection(?:5))
+"Test port facility", "expt1", "one", "ds2", "df1 \t \r \n \\ \f \b \' \"",  "a"
+"Test port facility", "expt1", "one", "ds2", "df2",  "b"
+
+Job(application(facility(name:0), name:1, version:2), inputDataCollection(?:3), outputDataCollection(?:4))
+"Test port facility", "aprog", "1.2.3", "a", "b"
+

--- a/src/test/resources/icat.port
+++ b/src/test/resources/icat.port
@@ -83,6 +83,7 @@ DataCollection(?:0)
 "a"
 "b"
 "c"
+"d"
 
 DataCollectionDatafile(datafile(dataset(investigation(facility(name:0), name:1, visitId:2), name:3), name:4), dataCollection(?:5))
 "Test port facility", "expt1", "one", "ds2", "df1 \t \r \n \\ \f \b \' \"",  "a"
@@ -91,3 +92,29 @@ DataCollectionDatafile(datafile(dataset(investigation(facility(name:0), name:1, 
 Job(application(facility(name:0), name:1, version:2), inputDataCollection(?:3), outputDataCollection(?:4))
 "Test port facility", "aprog", "1.2.3", "a", "b"
 
+DataPublicationType(description:0, facility(name:1), name:2)
+"Curated data publication", "Test port facility", "curated"
+"Open access raw data", "Test port facility", "raw"
+
+DataPublication(content(?:0), description:1, facility(name:2), pid:3, publicationDate:4, subject:5, title:6, type(facility(name:7), name:8))
+"d", "We provide the first 65535 integers from sequence A000027 of the On-Line Encyclopedia of Integer Sequences. The data consists of an HDF5 file, having one single entry: a one dimensional integer array.", "Test port facility", "DOI:00.0815/pub-00027", 2022-10-31T00:00:00.000+01:00, "integer sequence; OEIS; On-Line Encyclopedia of Integer Sequences", "Data from OEIS sequence A000027", "Test port facility", "curated"
+
+DataPublicationDate(date:0, dateType:1, publication(facility(name:2), pid:3))
+"2012-08-01", "Created", "Test port facility", "DOI:00.0815/pub-00027"
+"2022-04-29", "Submitted", "Test port facility", "DOI:00.0815/pub-00027"
+
+DataPublicationUser(contributorType:0, email:1, familyName:2, fullName:3, givenName:4, orderKey:5, publication(facility(name:6), pid:7), user(name:8))
+"Creator", null, "Brown", "Brown, Fred", "Fred", "01", "Test port facility", "DOI:00.0815/pub-00027", "db/fred"
+
+Affiliation(fullReference:0, name:1, pid:2, user(contributorType:3, publication(facility(name:4), pid:5), user(name:6)))
+"University of Chicago", "02: Chicago", "ROR:024mw5h28", "Creator", "Test port facility", "DOI:00.0815/pub-00027", "db/fred"
+"Université de Nancy", "01: Nancy", null, "Creator", "Test port facility", "DOI:00.0815/pub-00027", "db/fred"
+
+RelatedItem(fullReference:0, identifier:1, publication(facility(name:2), pid:3), relatedItemType:4, relationType:5, title:6)
+"OEIS Foundation Inc. (2022), The positive integers, Entry A000027 in The On-Line Encyclopedia of Integer Sequences", "URL:http://oeis.org/A000027", "Test port facility", "DOI:00.0815/pub-00027", "Other", "References", "The positive integers"
+
+FundingReference(awardNumber:0, awardTitle:1, funderIdentifier:2, funderName:3)
+"AIS3241330750", null, "Crossref Funder ID:10.13039/100005376", "American Mathematical Society"
+
+DataPublicationFunding(dataPublication(facility(name:0), pid:1), funding(awardNumber:2, funderName:3))
+"Test port facility", "DOI:00.0815/pub-00027", "AIS3241330750", "American Mathematical Society"


### PR DESCRIPTION
Add more content to `src/test/resources/icat.port`, the test data to be used in the integration tests in `TestRS`, including a `DataPublication` and related objects. This is needed to build specific tests in #366 and #370 upon.

Note that the for different reasons the tests `exportMetaDataDumpUser()`, `exportMetaDataDumpRoot()`, `importMetaDataUser()`, and `importMetaDataAll()` cannot use test metadata containing a `DataPublication`. These tests now use a dedicated, reduced set of metadata (the old set).

Also note that this PR does not need to be reviewed or merged to `master`, it will implicitly be merged together with either #366 and #370. I open this PR for the sake of documentation.