### PR TITLE
Isolate the Session table in a separate persistence context

### DIFF
--- a/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
+++ b/src/main/java/org/icatproject/core/manager/EntityBeanManager.java
@@ -68,7 +68,6 @@ import org.icatproject.core.entity.Investigation;
 import org.icatproject.core.entity.InvestigationInstrument;
 import org.icatproject.core.entity.ParameterValueType;
 import org.icatproject.core.entity.Sample;
-import org.icatproject.core.entity.Session;
 import org.icatproject.core.manager.EntityInfoHandler.Relationship;
 import org.icatproject.core.manager.PropertyHandler.CallType;
 import org.icatproject.core.manager.PropertyHandler.Operation;
@@ -142,6 +141,9 @@ public class EntityBeanManager {
 
 	@EJB
 	SearchManager searchManager;
+
+	@EJB
+	SessionManager sessionManager;
 
 	@Resource
 	UserTransaction userTransaction;
@@ -1108,12 +1110,6 @@ public class EntityBeanManager {
 		return propertyHandler.props();
 	}
 
-	public double getRemainingMinutes(String sessionId) throws IcatException {
-		logger.debug("getRemainingMinutes for sessionId " + sessionId);
-		Session session = getSession(sessionId);
-		return session.getRemainingMinutes();
-	}
-
 	private String getRep(Field field, Object value) throws IcatException {
 		String type = field.getType().getSimpleName();
 		if (type.equals("String")) {
@@ -1135,31 +1131,6 @@ public class EntityBeanManager {
 			return value.toString();
 		} else {
 			throw new IcatException(IcatExceptionType.INTERNAL, "Don't know how to export field of type " + type);
-		}
-	}
-
-	private Session getSession(String sessionId) throws IcatException {
-		Session session = null;
-		if (sessionId == null || sessionId.equals("")) {
-			throw new IcatException(IcatException.IcatExceptionType.SESSION, "Session Id cannot be null or empty.");
-		}
-		session = (Session) entityManager.find(Session.class, sessionId);
-		if (session == null) {
-			throw new IcatException(IcatException.IcatExceptionType.SESSION,
-					"Unable to find user by sessionid: " + sessionId);
-		}
-		return session;
-	}
-
-	public String getUserName(String sessionId) throws IcatException {
-		try {
-			Session session = getSession(sessionId);
-			String userName = session.getUserName();
-			logger.debug("user: " + userName + " is associated with: " + sessionId);
-			return userName;
-		} catch (IcatException e) {
-			logger.debug("sessionId " + sessionId + " is not associated with valid session " + e.getMessage());
-			throw e;
 		}
 	}
 
@@ -1211,11 +1182,6 @@ public class EntityBeanManager {
 				return false;
 			}
 		}
-	}
-
-	public boolean isLoggedIn(String userName) {
-		logger.debug("isLoggedIn for user " + userName);
-		return entityManager.createNamedQuery(Session.ISLOGGEDIN, Long.class).setParameter("userName", userName).getSingleResult() > 0;
 	}
 
 	private void isUnique(EntityBaseBean bean) throws IcatException {
@@ -1288,89 +1254,6 @@ public class EntityBeanManager {
 			}
 		}
 
-	}
-
-	public String login(String userName, int lifetimeMinutes, String ip) throws IcatException {
-		Session session = new Session(userName, lifetimeMinutes);
-		try {
-			userTransaction.begin();
-			try {
-				long startMillis = log ? System.currentTimeMillis() : 0;
-				entityManager.persist(session);
-				entityManager.flush();
-				userTransaction.commit();
-				String result = session.getId();
-				logger.debug("Session " + result + " persisted.");
-				if (logRequests.contains(CallType.SESSION)) {
-					ByteArrayOutputStream baos = new ByteArrayOutputStream();
-					try (JsonGenerator gen = Json.createGenerator(baos).writeStartObject()) {
-						gen.write("userName", userName);
-						gen.writeEnd();
-					}
-					transmitter.processMessage("login", ip, baos.toString(), startMillis);
-				}
-				return result;
-			} catch (Throwable e) {
-				userTransaction.rollback();
-				logger.trace("Transaction rolled back for login because of " + e.getClass() + " " + e.getMessage());
-				throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
-						"Unexpected DB response " + e.getClass() + " " + e.getMessage());
-			}
-		} catch (IllegalStateException e) {
-			throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
-					"IllegalStateException " + e.getMessage());
-		} catch (SecurityException e) {
-			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "SecurityException " + e.getMessage());
-		} catch (SystemException e) {
-			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "SystemException " + e.getMessage());
-		} catch (NotSupportedException e) {
-			throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
-					"NotSupportedException " + e.getMessage());
-		}
-	}
-
-	public void logout(String sessionId, String ip) throws IcatException {
-		logger.debug("logout for sessionId " + sessionId);
-		try {
-			userTransaction.begin();
-			try {
-				long startMillis = log ? System.currentTimeMillis() : 0;
-				Session session = getSession(sessionId);
-				entityManager.remove(session);
-				entityManager.flush();
-				userTransaction.commit();
-				logger.debug("Session {} removed.", session.getId());
-				if (logRequests.contains(CallType.SESSION)) {
-					ByteArrayOutputStream baos = new ByteArrayOutputStream();
-					try (JsonGenerator gen = Json.createGenerator(baos).writeStartObject()) {
-						gen.write("userName", session.getUserName());
-						gen.writeEnd();
-					}
-					transmitter.processMessage("logout", ip, baos.toString(), startMillis);
-				}
-			} catch (IcatException e) {
-				userTransaction.rollback();
-				logger.trace("Transaction rolled back for logout because of " + e.getClass() + " " + e.getMessage());
-				if (e.getType() == IcatExceptionType.SESSION) {
-					throw e;
-				} else {
-					throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
-							e.getClass() + " " + e.getMessage());
-				}
-			} catch (Exception e) {
-				throw new IcatException(IcatException.IcatExceptionType.INTERNAL, e.getClass() + " " + e.getMessage());
-			}
-		} catch (IllegalStateException e) {
-			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "IllegalStateException" + e.getMessage());
-		} catch (SecurityException e) {
-			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "SecurityException" + e.getMessage());
-		} catch (SystemException e) {
-			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "SystemException" + e.getMessage());
-		} catch (NotSupportedException e) {
-			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "NotSupportedException" + e.getMessage());
-		} catch (RuntimeException e) {
-			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, e.getClass() + " " + e.getMessage());
-		}
 	}
 
 	public EntityBaseBean lookup(EntityBaseBean bean) throws IcatException {
@@ -1956,48 +1839,6 @@ public class EntityBeanManager {
 		parseEntity(bean, contents, klass, creates, localUpdates, create, userId);
 		return bean;
 
-	}
-
-	public void refresh(String sessionId, int lifetimeMinutes, String ip) throws IcatException {
-		logger.debug("logout for sessionId " + sessionId);
-		try {
-			userTransaction.begin();
-			try {
-				long startMillis = log ? System.currentTimeMillis() : 0;
-				Session session = getSession(sessionId);
-				session.refresh(lifetimeMinutes);
-				entityManager.flush();
-				userTransaction.commit();
-				logger.debug("Session {} refreshed.", session.getId());
-				if (logRequests.contains(CallType.SESSION)) {
-					ByteArrayOutputStream baos = new ByteArrayOutputStream();
-					try (JsonGenerator gen = Json.createGenerator(baos).writeStartObject()) {
-						gen.write("userName", session.getUserName());
-						gen.writeEnd();
-					}
-					transmitter.processMessage("refresh", ip, baos.toString(), startMillis);
-				}
-			} catch (IcatException e) {
-				userTransaction.rollback();
-				logger.trace("Transaction rolled back for logout because of " + e.getClass() + " " + e.getMessage());
-				if (e.getType() == IcatExceptionType.SESSION) {
-					throw e;
-				} else {
-					throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
-							e.getClass() + " " + e.getMessage());
-				}
-			} catch (Exception e) {
-				throw new IcatException(IcatException.IcatExceptionType.INTERNAL, e.getClass() + " " + e.getMessage());
-			}
-		} catch (IllegalStateException e) {
-			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "IllegalStateException" + e.getMessage());
-		} catch (SecurityException e) {
-			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "SecurityException" + e.getMessage());
-		} catch (SystemException e) {
-			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "SystemException" + e.getMessage());
-		} catch (NotSupportedException e) {
-			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "NotSupportedException" + e.getMessage());
-		}
 	}
 
 	public List<?> search(String userId, String query, String ip) throws IcatException {

--- a/src/main/java/org/icatproject/core/manager/Porter.java
+++ b/src/main/java/org/icatproject/core/manager/Porter.java
@@ -39,7 +39,6 @@ import org.icatproject.core.IcatException;
 import org.icatproject.core.IcatException.IcatExceptionType;
 import org.icatproject.core.entity.EntityBaseBean;
 import org.icatproject.core.entity.ParameterValueType;
-import org.icatproject.core.entity.Session;
 import org.icatproject.core.manager.importParser.Attribute;
 import org.icatproject.core.manager.importParser.Input;
 import org.icatproject.core.manager.importParser.ParserException;
@@ -83,6 +82,9 @@ public class Porter {
 
 	@EJB
 	PropertyHandler propertyHandler;
+
+	@EJB
+	SessionManager sessionManager;
 
 	private Set<String> rootUserNames;
 
@@ -185,7 +187,7 @@ public class Porter {
 			}
 		}
 
-		String userId = getUserName(sessionId, entityManager);
+		String userId = sessionManager.getUserName(sessionId);
 		boolean allAttributes = attributes == Attributes.ALL;
 		if (allAttributes && !rootUserNames.contains(userId)) {
 			throw new IcatException(IcatExceptionType.INSUFFICIENT_PRIVILEGES,
@@ -248,31 +250,6 @@ public class Porter {
 		} catch (IllegalArgumentException | InvocationTargetException | IllegalAccessException e) {
 			throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
 					e.getClass().getSimpleName() + " " + e.getMessage() + " at line " + linum, linum);
-		}
-	}
-
-	private Session getSession(String sessionId, EntityManager entityManager) throws IcatException {
-		Session session = null;
-		if (sessionId == null || sessionId.equals("")) {
-			throw new IcatException(IcatException.IcatExceptionType.SESSION, "Session Id cannot be null or empty.");
-		}
-		session = entityManager.find(Session.class, sessionId);
-		if (session == null) {
-			throw new IcatException(IcatException.IcatExceptionType.SESSION,
-					"Unable to find user by sessionid: " + sessionId);
-		}
-		return session;
-	}
-
-	private String getUserName(String sessionId, EntityManager entityManager) throws IcatException {
-		try {
-			Session session = getSession(sessionId, entityManager);
-			String userName = session.getUserName();
-			logger.debug("user: " + userName + " is associated with: " + sessionId);
-			return userName;
-		} catch (IcatException e) {
-			logger.debug("sessionId " + sessionId + " is not associated with valid session " + e.getMessage());
-			throw e;
 		}
 	}
 
@@ -585,7 +562,7 @@ public class Porter {
 		return table;
 	}
 
-	public Response exportData(String jsonString, EntityManager entityManager) throws IcatException {
+	public Response exportData(String jsonString) throws IcatException {
 		if (jsonString == null) {
 			throw new IcatException(IcatExceptionType.BAD_PARAMETER, "json must not be null");
 		}
@@ -618,7 +595,7 @@ public class Porter {
 			}
 		}
 		logger.debug(sessionId + " issues " + query);
-		String userId = getUserName(sessionId, entityManager);
+		String userId = sessionManager.getUserName(sessionId);
 		if (query != null) {
 			return beanManager.export(userId, query, attributes == Attributes.ALL);
 		} else {

--- a/src/main/java/org/icatproject/core/manager/SessionManager.java
+++ b/src/main/java/org/icatproject/core/manager/SessionManager.java
@@ -1,21 +1,56 @@
 package org.icatproject.core.manager;
 
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.Resource;
+import jakarta.ejb.EJB;
 import jakarta.ejb.Schedule;
 import jakarta.ejb.Singleton;
+import jakarta.ejb.TransactionManagement;
+import jakarta.ejb.TransactionManagementType;
+import jakarta.json.Json;
+import jakarta.json.stream.JsonGenerator;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.PersistenceContext;
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.UserTransaction;
 
+import java.io.ByteArrayOutputStream;
+import java.util.Set;
+
+import org.icatproject.core.IcatException;
+import org.icatproject.core.IcatException.IcatExceptionType;
 import org.icatproject.core.entity.Session;
+import org.icatproject.core.manager.PropertyHandler.CallType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @Singleton
+@TransactionManagement(TransactionManagementType.BEAN)
 public class SessionManager {
 
 	private static final Logger logger = LoggerFactory.getLogger(SessionManager.class);
 
-	@PersistenceContext(unitName = "icat")
-	private EntityManager entityManager;
+	@EJB
+	Transmitter transmitter;
+
+	@Resource
+	UserTransaction userTransaction;
+
+	@PersistenceContext(unitName = "session")
+	EntityManager entityManager;
+
+	@EJB
+	PropertyHandler propertyHandler;
+
+	private boolean log;
+	private Set<CallType> logRequests;
+
+	@PostConstruct
+	void init() {
+		logRequests = propertyHandler.getLogSet();
+		log = !logRequests.isEmpty();
+	}
 
 	// Run every hour
 	@Schedule(hour = "*")
@@ -25,6 +60,168 @@ public class SessionManager {
 			logger.debug(n + " sessions were removed");
 		} catch (Throwable e) {
 			logger.error(e.getClass() + " " + e.getMessage());
+		}
+	}
+
+	public double getRemainingMinutes(String sessionId) throws IcatException {
+		logger.debug("getRemainingMinutes for sessionId " + sessionId);
+		Session session = getSession(sessionId);
+		return session.getRemainingMinutes();
+	}
+
+
+	private Session getSession(String sessionId) throws IcatException {
+		Session session = null;
+		if (sessionId == null || sessionId.equals("")) {
+			throw new IcatException(IcatException.IcatExceptionType.SESSION, "Session Id cannot be null or empty.");
+		}
+		session = (Session) entityManager.find(Session.class, sessionId);
+		if (session == null) {
+			throw new IcatException(IcatException.IcatExceptionType.SESSION,
+					"Unable to find user by sessionid: " + sessionId);
+		}
+		return session;
+	}
+
+	public String getUserName(String sessionId) throws IcatException {
+		try {
+			Session session = getSession(sessionId);
+			String userName = session.getUserName();
+			logger.debug("user: " + userName + " is associated with: " + sessionId);
+			return userName;
+		} catch (IcatException e) {
+			logger.debug("sessionId " + sessionId + " is not associated with valid session " + e.getMessage());
+			throw e;
+		}
+	}
+
+	public boolean isLoggedIn(String userName) {
+		logger.debug("isLoggedIn for user " + userName);
+		return entityManager.createNamedQuery(Session.ISLOGGEDIN, Long.class).setParameter("userName", userName).getSingleResult() > 0;
+	}
+
+	public String login(String userName, int lifetimeMinutes, String ip) throws IcatException {
+		Session session = new Session(userName, lifetimeMinutes);
+		try {
+			userTransaction.begin();
+			try {
+				long startMillis = log ? System.currentTimeMillis() : 0;
+				entityManager.persist(session);
+				entityManager.flush();
+				userTransaction.commit();
+				String result = session.getId();
+				logger.debug("Session " + result + " persisted.");
+				if (logRequests.contains(CallType.SESSION)) {
+					ByteArrayOutputStream baos = new ByteArrayOutputStream();
+					try (JsonGenerator gen = Json.createGenerator(baos).writeStartObject()) {
+						gen.write("userName", userName);
+						gen.writeEnd();
+					}
+					transmitter.processMessage("login", ip, baos.toString(), startMillis);
+				}
+				return result;
+			} catch (Throwable e) {
+				userTransaction.rollback();
+				logger.trace("Transaction rolled back for login because of " + e.getClass() + " " + e.getMessage());
+				throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
+						"Unexpected DB response " + e.getClass() + " " + e.getMessage());
+			}
+		} catch (IllegalStateException e) {
+			throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
+					"IllegalStateException " + e.getMessage());
+		} catch (SecurityException e) {
+			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "SecurityException " + e.getMessage());
+		} catch (SystemException e) {
+			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "SystemException " + e.getMessage());
+		} catch (NotSupportedException e) {
+			throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
+					"NotSupportedException " + e.getMessage());
+		}
+	}
+
+	public void logout(String sessionId, String ip) throws IcatException {
+		logger.debug("logout for sessionId " + sessionId);
+		try {
+			userTransaction.begin();
+			try {
+				long startMillis = log ? System.currentTimeMillis() : 0;
+				Session session = getSession(sessionId);
+				entityManager.remove(session);
+				entityManager.flush();
+				userTransaction.commit();
+				logger.debug("Session {} removed.", session.getId());
+				if (logRequests.contains(CallType.SESSION)) {
+					ByteArrayOutputStream baos = new ByteArrayOutputStream();
+					try (JsonGenerator gen = Json.createGenerator(baos).writeStartObject()) {
+						gen.write("userName", session.getUserName());
+						gen.writeEnd();
+					}
+					transmitter.processMessage("logout", ip, baos.toString(), startMillis);
+				}
+			} catch (IcatException e) {
+				userTransaction.rollback();
+				logger.trace("Transaction rolled back for logout because of " + e.getClass() + " " + e.getMessage());
+				if (e.getType() == IcatExceptionType.SESSION) {
+					throw e;
+				} else {
+					throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
+							e.getClass() + " " + e.getMessage());
+				}
+			} catch (Exception e) {
+				throw new IcatException(IcatException.IcatExceptionType.INTERNAL, e.getClass() + " " + e.getMessage());
+			}
+		} catch (IllegalStateException e) {
+			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "IllegalStateException" + e.getMessage());
+		} catch (SecurityException e) {
+			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "SecurityException" + e.getMessage());
+		} catch (SystemException e) {
+			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "SystemException" + e.getMessage());
+		} catch (NotSupportedException e) {
+			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "NotSupportedException" + e.getMessage());
+		} catch (RuntimeException e) {
+			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, e.getClass() + " " + e.getMessage());
+		}
+	}
+
+	public void refresh(String sessionId, int lifetimeMinutes, String ip) throws IcatException {
+		logger.debug("logout for sessionId " + sessionId);
+		try {
+			userTransaction.begin();
+			try {
+				long startMillis = log ? System.currentTimeMillis() : 0;
+				Session session = getSession(sessionId);
+				session.refresh(lifetimeMinutes);
+				entityManager.flush();
+				userTransaction.commit();
+				logger.debug("Session {} refreshed.", session.getId());
+				if (logRequests.contains(CallType.SESSION)) {
+					ByteArrayOutputStream baos = new ByteArrayOutputStream();
+					try (JsonGenerator gen = Json.createGenerator(baos).writeStartObject()) {
+						gen.write("userName", session.getUserName());
+						gen.writeEnd();
+					}
+					transmitter.processMessage("refresh", ip, baos.toString(), startMillis);
+				}
+			} catch (IcatException e) {
+				userTransaction.rollback();
+				logger.trace("Transaction rolled back for logout because of " + e.getClass() + " " + e.getMessage());
+				if (e.getType() == IcatExceptionType.SESSION) {
+					throw e;
+				} else {
+					throw new IcatException(IcatException.IcatExceptionType.INTERNAL,
+							e.getClass() + " " + e.getMessage());
+				}
+			} catch (Exception e) {
+				throw new IcatException(IcatException.IcatExceptionType.INTERNAL, e.getClass() + " " + e.getMessage());
+			}
+		} catch (IllegalStateException e) {
+			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "IllegalStateException" + e.getMessage());
+		} catch (SecurityException e) {
+			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "SecurityException" + e.getMessage());
+		} catch (SystemException e) {
+			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "SystemException" + e.getMessage());
+		} catch (NotSupportedException e) {
+			throw new IcatException(IcatException.IcatExceptionType.INTERNAL, "NotSupportedException" + e.getMessage());
 		}
 	}
 }

--- a/src/main/java/org/icatproject/core/manager/SessionManager.java
+++ b/src/main/java/org/icatproject/core/manager/SessionManager.java
@@ -45,11 +45,13 @@ public class SessionManager {
 
 	private boolean log;
 	private Set<CallType> logRequests;
+	private int lifetimeMinutes;
 
 	@PostConstruct
 	void init() {
 		logRequests = propertyHandler.getLogSet();
 		log = !logRequests.isEmpty();
+		lifetimeMinutes = propertyHandler.getLifetimeMinutes();
 	}
 
 	// Run every hour
@@ -100,7 +102,7 @@ public class SessionManager {
 		return entityManager.createNamedQuery(Session.ISLOGGEDIN, Long.class).setParameter("userName", userName).getSingleResult() > 0;
 	}
 
-	public String login(String userName, int lifetimeMinutes, String ip) throws IcatException {
+	public String login(String userName, String ip) throws IcatException {
 		Session session = new Session(userName, lifetimeMinutes);
 		try {
 			userTransaction.begin();
@@ -183,7 +185,7 @@ public class SessionManager {
 		}
 	}
 
-	public void refresh(String sessionId, int lifetimeMinutes, String ip) throws IcatException {
+	public void refresh(String sessionId, String ip) throws IcatException {
 		logger.debug("logout for sessionId " + sessionId);
 		try {
 			userTransaction.begin();

--- a/src/main/java/org/icatproject/core/manager/SessionManager.java
+++ b/src/main/java/org/icatproject/core/manager/SessionManager.java
@@ -60,10 +60,12 @@ public class SessionManager {
 	@Schedule(hour = "*")
 	public void removeExpiredSessions() {
 		try {
+			userTransaction.begin();
 			int n = sessionEntityManager.createNamedQuery(Session.DELETE_EXPIRED).executeUpdate();
+			userTransaction.commit();
 			logger.debug(n + " sessions were removed");
-		} catch (Throwable e) {
-			logger.error(e.getClass() + " " + e.getMessage());
+		} catch (Exception e) {
+			logger.error("Error removing expired sessions", e);
 		}
 	}
 

--- a/src/main/java/org/icatproject/exposed/ICAT.java
+++ b/src/main/java/org/icatproject/exposed/ICAT.java
@@ -88,8 +88,6 @@ public class ICAT {
 	@EJB
 	EntityBeanManager beanManager;
 
-	private int lifetimeMinutes;
-
 	@EJB
 	PropertyHandler propertyHandler;
 
@@ -275,7 +273,6 @@ public class ICAT {
 	@PostConstruct
 	private void init() {
 		authPlugins = propertyHandler.getAuthPlugins();
-		lifetimeMinutes = propertyHandler.getLifetimeMinutes();
 		rootUserNames = propertyHandler.getRootUserNames();
 	}
 
@@ -308,7 +305,7 @@ public class ICAT {
 		Authenticator authenticator = extendedAuthenticator.getAuthenticator();
 		logger.debug("Using " + plugin + " to authenticate");
 		String userName = authenticator.authenticate(credentials, ip).getUserName();
-		return sessionManager.login(userName, lifetimeMinutes, ip);
+		return sessionManager.login(userName, ip);
 	}
 
 	@AroundInvoke
@@ -347,7 +344,7 @@ public class ICAT {
 	public void refresh(@WebParam(name = "sessionId") String sessionId) throws IcatException {
 		String ip = ((HttpServletRequest) webServiceContext.getMessageContext().get(MessageContext.SERVLET_REQUEST))
 				.getRemoteAddr();
-		sessionManager.refresh(sessionId, lifetimeMinutes, ip);
+		sessionManager.refresh(sessionId, ip);
 	}
 
 	private void reportIcatException(IcatException e) throws IcatException {

--- a/src/main/java/org/icatproject/exposed/ICATRest.java
+++ b/src/main/java/org/icatproject/exposed/ICATRest.java
@@ -880,7 +880,7 @@ public class ICATRest {
 		logger.debug("Using " + plugin + " to authenticate");
 
 		String userName = authenticator.authenticate(credentials, request.getRemoteAddr()).getUserName();
-		String sessionId = sessionManager.login(userName, lifetimeMinutes, request.getRemoteAddr());
+		String sessionId = sessionManager.login(userName, request.getRemoteAddr());
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		JsonGenerator gen = Json.createGenerator(baos);
@@ -1587,7 +1587,7 @@ public class ICATRest {
 	@Path("session/{sessionId}")
 	public void refresh(@Context HttpServletRequest request, @PathParam("sessionId") String sessionId)
 			throws IcatException {
-		sessionManager.refresh(sessionId, lifetimeMinutes, request.getRemoteAddr());
+		sessionManager.refresh(sessionId, request.getRemoteAddr());
 	}
 
 	/**

--- a/src/main/java/org/icatproject/exposed/ICATRest.java
+++ b/src/main/java/org/icatproject/exposed/ICATRest.java
@@ -76,6 +76,7 @@ import org.icatproject.core.manager.EntityInfoHandler;
 import org.icatproject.core.manager.GateKeeper;
 import org.icatproject.core.manager.Porter;
 import org.icatproject.core.manager.PropertyHandler;
+import org.icatproject.core.manager.SessionManager;
 import org.icatproject.core.manager.PropertyHandler.ExtendedAuthenticator;
 import org.icatproject.core.manager.search.FacetDimension;
 import org.icatproject.core.manager.search.FacetLabel;
@@ -113,6 +114,9 @@ public class ICATRest {
 	@EJB
 	PropertyHandler propertyHandler;
 
+	@EJB
+	SessionManager sessionManager;
+
 	private Set<String> rootUserNames;
 
 	private int maxEntities;
@@ -122,7 +126,7 @@ public class ICATRest {
 	private Map<String, String> cluster;
 
 	private void checkRoot(String sessionId) throws IcatException {
-		String userId = beanManager.getUserName(sessionId);
+		String userId = sessionManager.getUserName(sessionId);
 		if (!rootUserNames.contains(userId)) {
 			throw new IcatException(IcatExceptionType.INSUFFICIENT_PRIVILEGES, "user must be in rootUserNames");
 		}
@@ -169,7 +173,7 @@ public class ICATRest {
 	public String write(@Context HttpServletRequest request, @FormParam("sessionId") String sessionId,
 			@FormParam("entities") String json) throws IcatException {
 
-		String userName = beanManager.getUserName(sessionId);
+		String userName = sessionManager.getUserName(sessionId);
 
 		List<Long> beanIds = beanManager.write(userName, json, request.getRemoteAddr());
 
@@ -216,7 +220,7 @@ public class ICATRest {
 			@FormParam("name") String name, @FormParam("id") long id, @FormParam("keys") String keys)
 			throws IcatException {
 
-		String userName = beanManager.getUserName(sessionId);
+		String userName = sessionManager.getUserName(sessionId);
 
 		long beanId = beanManager.cloneEntity(userName, name, id, keys, request.getRemoteAddr());
 
@@ -267,7 +271,7 @@ public class ICATRest {
 		} catch (JsonException e) {
 			throw new IcatException(IcatExceptionType.BAD_PARAMETER, e.getMessage() + " in json " + json);
 		}
-		String userName = beanManager.getUserName(sessionId);
+		String userName = sessionManager.getUserName(sessionId);
 		beanManager.delete(userName, beans, request.getRemoteAddr());
 	}
 
@@ -342,7 +346,7 @@ public class ICATRest {
 	@Path("port")
 	@Produces(MediaType.TEXT_PLAIN)
 	public Response exportData(@QueryParam("json") String jsonString) throws IcatException {
-		return porter.exportData(jsonString, entityManager);
+		return porter.exportData(jsonString);
 	}
 
 	/**
@@ -479,8 +483,8 @@ public class ICATRest {
 	@Produces(MediaType.APPLICATION_JSON)
 	public String getSession(@PathParam("sessionId") String sessionId) throws IcatException {
 
-		String userName = beanManager.getUserName(sessionId);
-		double remainingMinutes = beanManager.getRemainingMinutes(sessionId);
+		String userName = sessionManager.getUserName(sessionId);
+		double remainingMinutes = sessionManager.getRemainingMinutes(sessionId);
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		JsonGenerator gen = Json.createGenerator(baos);
@@ -507,7 +511,7 @@ public class ICATRest {
 	public String isLoggedIn1(@PathParam("userName") String userName) {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		try (JsonGenerator gen = Json.createGenerator(baos)) {
-			gen.writeStartObject().write("loggedIn", beanManager.isLoggedIn(userName)).writeEnd();
+			gen.writeStartObject().write("loggedIn", sessionManager.isLoggedIn(userName)).writeEnd();
 		}
 		return baos.toString();
 	}
@@ -561,7 +565,7 @@ public class ICATRest {
 	public String isLoggedIn2(@PathParam("mnemonic") String mnemonic, @PathParam("userName") String userName) {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		try (JsonGenerator gen = Json.createGenerator(baos)) {
-			gen.writeStartObject().write("loggedIn", beanManager.isLoggedIn(mnemonic + "/" + userName))
+			gen.writeStartObject().write("loggedIn", sessionManager.isLoggedIn(mnemonic + "/" + userName))
 					.writeEnd();
 		}
 		return baos.toString();
@@ -876,7 +880,7 @@ public class ICATRest {
 		logger.debug("Using " + plugin + " to authenticate");
 
 		String userName = authenticator.authenticate(credentials, request.getRemoteAddr()).getUserName();
-		String sessionId = beanManager.login(userName, lifetimeMinutes, request.getRemoteAddr());
+		String sessionId = sessionManager.login(userName, lifetimeMinutes, request.getRemoteAddr());
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		JsonGenerator gen = Json.createGenerator(baos);
@@ -902,7 +906,7 @@ public class ICATRest {
 	@Path("session/{sessionId}")
 	public void logout(@Context HttpServletRequest request, @PathParam("sessionId") String sessionId)
 			throws IcatException {
-		beanManager.logout(sessionId, request.getRemoteAddr());
+		sessionManager.logout(sessionId, request.getRemoteAddr());
 	}
 
 	/**
@@ -1019,7 +1023,7 @@ public class ICATRest {
 		if (query == null) {
 			throw new IcatException(IcatExceptionType.BAD_PARAMETER, "query is not set");
 		}
-		String userName = beanManager.getUserName(sessionId);
+		String userName = sessionManager.getUserName(sessionId);
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		try (JsonReader jr = Json.createReader(new ByteArrayInputStream(query.getBytes()))) {
 			JsonObject jo = jr.readObject();
@@ -1213,7 +1217,7 @@ public class ICATRest {
 		if (maxCount == 0) {
 			maxCount = 100;
 		}
-		String userName = beanManager.getUserName(sessionId);
+		String userName = sessionManager.getUserName(sessionId);
 		JsonValue searchAfterValue = null;
 		if (searchAfter != null && searchAfter.length() > 0) {
 			try (JsonReader jr = Json.createReader(new StringReader(searchAfter))) {
@@ -1583,7 +1587,7 @@ public class ICATRest {
 	@Path("session/{sessionId}")
 	public void refresh(@Context HttpServletRequest request, @PathParam("sessionId") String sessionId)
 			throws IcatException {
-		beanManager.refresh(sessionId, lifetimeMinutes, request.getRemoteAddr());
+		sessionManager.refresh(sessionId, lifetimeMinutes, request.getRemoteAddr());
 	}
 
 	/**
@@ -1634,7 +1638,7 @@ public class ICATRest {
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		JsonGenerator gen = Json.createGenerator(baos);
 
-		String userName = beanManager.getUserName(sessionId);
+		String userName = sessionManager.getUserName(sessionId);
 		if (id == null) {
 			gen.writeStartArray();
 			for (Object result : beanManager.search(userName, query, request.getRemoteAddr())) {

--- a/src/main/resources/META-INF/persistence.xml
+++ b/src/main/resources/META-INF/persistence.xml
@@ -9,6 +9,61 @@
 		<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
 		<jta-data-source>jdbc/icat</jta-data-source>
 
+		<class>org.icatproject.core.entity.Affiliation</class>
+		<class>org.icatproject.core.entity.Application</class>
+		<class>org.icatproject.core.entity.DataCollectionDatafile</class>
+		<class>org.icatproject.core.entity.DataCollectionDataset</class>
+		<class>org.icatproject.core.entity.DataCollectionInvestigation</class>
+		<class>org.icatproject.core.entity.DataCollection</class>
+		<class>org.icatproject.core.entity.DataCollectionParameter</class>
+		<class>org.icatproject.core.entity.DatafileFormat</class>
+		<class>org.icatproject.core.entity.Datafile</class>
+		<class>org.icatproject.core.entity.DatafileParameter</class>
+		<class>org.icatproject.core.entity.DataPublicationDate</class>
+		<class>org.icatproject.core.entity.DataPublicationFunding</class>
+		<class>org.icatproject.core.entity.DataPublication</class>
+		<class>org.icatproject.core.entity.DataPublicationType</class>
+		<class>org.icatproject.core.entity.DataPublicationUser</class>
+		<class>org.icatproject.core.entity.DatasetInstrument</class>
+		<class>org.icatproject.core.entity.Dataset</class>
+		<class>org.icatproject.core.entity.DatasetParameter</class>
+		<class>org.icatproject.core.entity.DatasetTechnique</class>
+		<class>org.icatproject.core.entity.DatasetType</class>
+		<class>org.icatproject.core.entity.FacilityCycle</class>
+		<class>org.icatproject.core.entity.Facility</class>
+		<class>org.icatproject.core.entity.FundingReference</class>
+		<class>org.icatproject.core.entity.Grouping</class>
+		<class>org.icatproject.core.entity.Instrument</class>
+		<class>org.icatproject.core.entity.InstrumentScientist</class>
+		<class>org.icatproject.core.entity.InvestigationFacilityCycle</class>
+		<class>org.icatproject.core.entity.InvestigationFunding</class>
+		<class>org.icatproject.core.entity.InvestigationGroup</class>
+		<class>org.icatproject.core.entity.InvestigationInstrument</class>
+		<class>org.icatproject.core.entity.Investigation</class>
+		<class>org.icatproject.core.entity.InvestigationParameter</class>
+		<class>org.icatproject.core.entity.InvestigationType</class>
+		<class>org.icatproject.core.entity.InvestigationUser</class>
+		<class>org.icatproject.core.entity.Job</class>
+		<class>org.icatproject.core.entity.Keyword</class>
+		<class>org.icatproject.core.entity.Parameter</class>
+		<class>org.icatproject.core.entity.ParameterType</class>
+		<class>org.icatproject.core.entity.PermissibleStringValue</class>
+		<class>org.icatproject.core.entity.Publication</class>
+		<class>org.icatproject.core.entity.PublicStep</class>
+		<class>org.icatproject.core.entity.RelatedDatafile</class>
+		<class>org.icatproject.core.entity.RelatedItem</class>
+		<class>org.icatproject.core.entity.Rule</class>
+		<class>org.icatproject.core.entity.Sample</class>
+		<class>org.icatproject.core.entity.SampleParameter</class>
+		<class>org.icatproject.core.entity.SampleType</class>
+		<class>org.icatproject.core.entity.Shift</class>
+		<class>org.icatproject.core.entity.StudyInvestigation</class>
+		<class>org.icatproject.core.entity.Study</class>
+		<class>org.icatproject.core.entity.Technique</class>
+		<class>org.icatproject.core.entity.UserGroup</class>
+		<class>org.icatproject.core.entity.User</class>
+		<exclude-unlisted-classes />
+
 		<properties>
 			<property name="eclipselink.cache.shared.default" value="false" />
 			<property name="eclipselink.logging.level" value="OFF" />
@@ -22,4 +77,24 @@
 		</properties>
 	</persistence-unit>
 
+
+	<persistence-unit name="session" transaction-type="JTA">
+		<provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+		<jta-data-source>jdbc/icat</jta-data-source>
+
+		<class>org.icatproject.core.entity.Session</class>
+		<exclude-unlisted-classes />
+
+		<properties>
+			<property name="eclipselink.cache.shared.default" value="false" />
+			<property name="eclipselink.logging.level" value="OFF" />
+			<property name="eclipselink.logging.level.sql" value="OFF" />
+			<property name="eclipselink.logging.parameters" value="false" />
+			<property name="eclipselink.ddl-generation" value="create-or-extend-tables" />
+			<property name="eclipselink.ddl-generation.output_mode" value="both" />
+			<property name="eclipselink.deploy-on-startup" value="true" />
+			<property name="eclipselink.target-server" value="Glassfish" />
+			<property name="eclipselink.target-database" value="Auto" />
+		</properties>
+	</persistence-unit>
 </persistence>


### PR DESCRIPTION
This moves the `Session` table into its own persistence context in order to separate it from the metadata tables in the persistence layer. The session management methods are moved from `BeanManager` to `SessionManager`.