### PR TITLE
Always set containerType to UNKNOWN

### DIFF
--- a/src/main/java/org/icatproject/core/manager/PropertyHandler.java
+++ b/src/main/java/org/icatproject/core/manager/PropertyHandler.java
@@ -54,8 +54,6 @@ import org.icatproject.core.IcatException.IcatExceptionType;
 import org.icatproject.core.manager.search.SearchManager;
 import org.icatproject.utils.CheckedProperties;
 import org.icatproject.utils.CheckedProperties.CheckedPropertyException;
-import org.icatproject.utils.ContainerGetter;
-import org.icatproject.utils.ContainerGetter.ContainerType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
@@ -301,7 +299,6 @@ public class PropertyHandler {
 	private int maxIdsInQuery;
 	private long importCacheSize;
 	private long exportCacheSize;
-	private ContainerType containerType;
 	private String jmsTopicConnectionFactory;
 	private String digestKey;
 	private SearchEngine searchEngine;
@@ -596,13 +593,6 @@ public class PropertyHandler {
 					"java:comp/DefaultJMSConnectionFactory");
 			formattedProps.add("jms.topicConnectionFactory " + jmsTopicConnectionFactory);
 
-			/* find type of container and set flags */
-			containerType = ContainerGetter.getContainer();
-			logger.info("ICAT has been deployed in a " + containerType + " container");
-			if (containerType == ContainerType.UNKNOWN) {
-				abend("Container type " + containerType + " is not recognised");
-			}
-
 			key = "search.indexBatchSize";
 			if (props.has(key)) {
 				searchIndexBatchSize = props.getPositiveInt(key);
@@ -675,10 +665,6 @@ public class PropertyHandler {
 
 	public long getExportCacheSize() {
 		return exportCacheSize;
-	}
-
-	public ContainerType getContainerType() {
-		return containerType;
 	}
 
 	public String getJmsTopicConnectionFactory() {

--- a/src/main/java/org/icatproject/exposed/ICATRest.java
+++ b/src/main/java/org/icatproject/exposed/ICATRest.java
@@ -121,8 +121,6 @@ public class ICATRest {
 
 	private int maxEntities;
 
-	private ContainerType containerType;
-
 	private Map<String, String> cluster;
 
 	private void checkRoot(String sessionId) throws IcatException {
@@ -452,8 +450,11 @@ public class ICATRest {
 			authenticatorArrayBuilder.add(authenticatorBuilder);
 		}
 
-		jsonBuilder.add("maxEntities", maxEntities).add("lifetimeMinutes", lifetimeMinutes)
-				.add("authenticators", authenticatorArrayBuilder).add("containerType", containerType.name());
+		jsonBuilder
+			.add("maxEntities", maxEntities)
+			.add("lifetimeMinutes", lifetimeMinutes)
+			.add("authenticators", authenticatorArrayBuilder)
+			.add("containerType", ContainerType.UNKNOWN.name()); // containerType kept for backwards compatibility but not disclosed
 
 		ByteArrayOutputStream baos = new ByteArrayOutputStream();
 		JsonWriter writer = Json.createWriter(baos);
@@ -680,7 +681,6 @@ public class ICATRest {
 		lifetimeMinutes = propertyHandler.getLifetimeMinutes();
 		rootUserNames = propertyHandler.getRootUserNames();
 		maxEntities = propertyHandler.getMaxEntities();
-		containerType = propertyHandler.getContainerType();
 		cluster = propertyHandler.getCluster();
 	}
 

--- a/src/test/java/org/icatproject/integration/TestWS.java
+++ b/src/test/java/org/icatproject/integration/TestWS.java
@@ -58,7 +58,6 @@ import org.icatproject.Study;
 import org.icatproject.User;
 import org.icatproject.UserGroup;
 import org.icatproject.core.manager.EntityInfoHandler;
-import org.icatproject.utils.ContainerGetter.ContainerType;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -1808,20 +1807,6 @@ public class TestWS {
 		assertEquals(0, results.size());
 		results = session.search("SELECT ds FROM Dataset ds WHERE ds.complete = FALSE");
 		assertEquals(4, results.size());
-
-		if (session.getContainerType() != ContainerType.Glassfish
-				&& session.getContainerType() != ContainerType.JBoss) {
-			// This should throw an exception as datafile is not an attribute of
-			// Dataset.
-			try {
-				results = session.search("SELECT ds from Dataset ds WHERE (SELECT COUNT(df) FROM ds.datafile df) = 2");
-				fail("Should have thrown an exception");
-			} catch (IcatException_Exception e) {
-				assertEquals(IcatExceptionType.BAD_PARAMETER, e.getFaultInfo().getType());
-				assertTrue(e.getMessage().indexOf("EntityManager") > 0
-						|| e.getMessage().indexOf("could not resolve property") > 0);
-			}
-		}
 
 		// Nested select
 		results = session.search("SELECT ds from Dataset ds WHERE (SELECT COUNT(df) FROM ds.datafiles df) = 2");


### PR DESCRIPTION
The `/icat/properties` endpoint discloses the runtime environment in the `containerType` property. It's not a good idea to disclose this unless necessary, and it fails for environments it cannot identify such as Payara Micro and Quarkus.

Instead of removing it completely, it is set to `UNKNOWN`. It may need to be set to `Glassfish` instead if there are existing applications that depend on that value.

Fixes #257
